### PR TITLE
Improve the Variant wrapper.

### DIFF
--- a/gdnative/build.rs
+++ b/gdnative/build.rs
@@ -158,11 +158,11 @@ impl {name} {{
                         writeln!(output, r#"
                 let {name}: Variant = if let Some(o) = {name} {{
                     o.into()
-                }} else {{ Variant::new_nil() }};
+                }} else {{ Variant::new() }};
                         "#, name = rust_safe_name(&argument.name)).unwrap();
                     } else if ty == "String" {
                         writeln!(output, r#"
-                let {name}: Variant = Variant::new_string({name});
+                let {name}: Variant = Variant::from_str({name});
                         "#, name = rust_safe_name(&argument.name)).unwrap();
                     } else {
                         writeln!(output, r#"

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -59,6 +59,7 @@ mod variant;
 mod rid;
 mod generated;
 mod node_path;
+mod string;
 
 pub use internal::*;
 pub use property::*;
@@ -70,6 +71,7 @@ pub use color::*;
 pub use rid::*;
 pub use node_path::*;
 pub use generated::*;
+pub use string::*;
 
 #[doc(hidden)]
 pub static mut GODOT_API: Option<GodotApi> = None;

--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -48,6 +48,19 @@ macro_rules! impl_basic_trait {
             }
         }
     };
+
+    (
+        Eq for $Type:ident as $GdType:ident : $gd_method:ident
+    ) => {
+        impl PartialEq for $Type {
+            fn eq(&self, other: &Self) -> bool {
+                unsafe {
+                    (get_api().$gd_method)(&self.0, &other.0)
+                }
+            }
+        }
+        impl Eq for $Type {}
+    };
 }
 
 macro_rules! impl_basic_traits {

--- a/gdnative/src/node_path.rs
+++ b/gdnative/src/node_path.rs
@@ -20,7 +20,7 @@ impl_basic_traits!(
     for NodePath as godot_node_path {
         Drop => godot_node_path_destroy;
         Clone => godot_node_path_new_copy;
-        PartialEq => godot_node_path_operator_equal;
+        Eq => godot_node_path_operator_equal;
         Default => default;
     }
 );

--- a/gdnative/src/rid.rs
+++ b/gdnative/src/rid.rs
@@ -2,7 +2,6 @@ use sys;
 use get_api;
 use std::mem::transmute;
 use std::cmp::{PartialEq, Eq};
-use std::hash::{Hash, Hasher};
 
 /// Resource Id.
 #[derive(Copy, Clone, Debug, Default)]
@@ -18,20 +17,12 @@ impl Rid {
     }
 
     fn to_u64(&self) -> u64 {
-        unsafe { transmute(*self) }
+        unsafe { transmute(self.0) }
     }
 }
 
-impl PartialEq for Rid {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { (get_api().godot_rid_operator_equal)(&self.0, &other.0) }
-    }
-}
-
-impl Eq for Rid {}
-
-impl Hash for Rid {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_u64().hash(state);
+impl_basic_traits!{
+    for Rid as godot_rid {
+        Eq => godot_rid_operator_equal;
     }
 }

--- a/gdnative/src/string.rs
+++ b/gdnative/src/string.rs
@@ -125,7 +125,7 @@ impl_basic_traits!(
     for GodotString as godot_string {
         Drop => godot_string_destroy;
         Clone => godot_string_new_copy;
-        PartialEq => godot_string_operator_equal;
+        Eq => godot_string_operator_equal;
         Default => default;
     }
 );


### PR DESCRIPTION
A few more methods, including `call` that may very well be completely unsafe/unsound.
I also renamed the `new_*` constructors into using the more idiomatic `from_*` prefix and they now take arguments by reference in most cases.