### PR TITLE
Experiment with a way to test the bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "sys",
     "gdnative",
     "geom",
+    "test",
     "example"
 ]

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 license = "MIT"
 workspace = ".."
 
+[features]
+gd_test = []
+
 [dependencies]
 gdnative-sys = { path = "../sys" }
 gdnative_geom = { path = "../geom" }

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -111,6 +111,7 @@ macro_rules! godot_init {
 
         #[no_mangle]
         #[doc(hidden)]
+        #[allow(unused_unsafe, unused_variables)]
         pub extern "C" fn godot_nativescript_init(desc: *mut $crate::libc::c_void) {
             unsafe {
                 $(

--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -80,3 +80,25 @@ macro_rules! impl_basic_traits {
         )*
     )
 }
+
+macro_rules! godot_test {
+    ($($test_name:ident $body:block)*) => {
+        $(
+            #[cfg(feature = "gd_test")]
+            pub fn $test_name() -> bool {
+                let str_name = stringify!($test_name);
+                println!("   -- {}", str_name);
+
+                let ok = ::std::panic::catch_unwind(
+                    || $body
+                ).is_ok();
+
+                if !ok {
+                    godot_error!("   !! Test {} failed", str_name);
+                }
+
+                ok
+            }
+        )*
+    }
+}

--- a/gdnative/src/string.rs
+++ b/gdnative/src/string.rs
@@ -222,3 +222,24 @@ impl_basic_traits! {
         Eq => godot_string_name_operator_equal;
     }
 }
+
+godot_test!(test_string {
+    use VariantType;
+    let foo = GodotString::from_str("foo");
+    assert_eq!(foo.len(), 3);
+
+    let foo_clone = foo.clone();
+    assert!(foo == foo_clone);
+
+    let variant = Variant::from_godot_string(&foo);
+    assert!(variant.get_type() == VariantType::GodotString);
+
+    let variant2 = Variant::from_str("foo");
+    assert!(variant == variant2);
+
+    if let Some(foo_variant) = variant.to_godot_string() {
+        assert!(foo_variant == foo);
+    } else {
+        panic!("variant should be a GodotString");
+    }
+});

--- a/gdnative/src/variant.rs
+++ b/gdnative/src/variant.rs
@@ -144,7 +144,7 @@ fn from_godot_varianty_type(v: sys::godot_variant_type) -> VariantType {
 // These aliases are just here so the type name matches the VariantType's variant names
 // to make writing macros easier.
 type F64 = f64;
-type I64 = f64;
+type I64 = i64;
 type Bool = bool;
 
 impl Variant {
@@ -326,9 +326,9 @@ impl Variant {
         self.get_type() == VariantType::Nil
     }
 
-    pub fn has_method(&mut self, method: &GodotString) -> bool {
+    pub fn has_method(&self, method: &GodotString) -> bool {
         unsafe {
-            (get_api().godot_variant_has_method)(&mut self.0, &method.0)
+            (get_api().godot_variant_has_method)(&self.0, &method.0)
         }
     }
 
@@ -454,3 +454,42 @@ impl <T> From<GodotRef<T>> for Variant
         Variant::from_object(o)
     }
 }
+
+godot_test!(
+    test_variant_nil {
+        let nil = Variant::new();
+        assert_eq!(nil.get_type(), VariantType::Nil);
+        assert!(nil.is_nil());
+
+        assert!(nil.to_array().is_none());
+        assert!(nil.to_rid().is_none());
+        assert!(nil.to_i64().is_none());
+        assert!(nil.to_bool().is_none());
+        assert!(nil.to_aabb().is_none());
+        assert!(nil.to_vector2().is_none());
+        assert!(nil.to_basis().is_none());
+
+        assert!(!nil.has_method(&GodotString::from_str("foo")));
+
+        let clone = nil.clone();
+        assert!(clone == nil);
+    }
+
+    test_variant_i64 {
+        let v_42 = Variant::from_i64(42);
+        assert_eq!(v_42.get_type(), VariantType::I64);
+
+        assert!(!v_42.is_nil());
+        assert_eq!(v_42.to_i64(), Some(42));
+        assert!(v_42.to_f64().is_none());
+        assert!(v_42.to_array().is_none());
+
+        let v_m1 = Variant::from_i64(-1);
+        assert_eq!(v_m1.get_type(), VariantType::I64);
+
+        assert!(!v_m1.is_nil());
+        assert_eq!(v_m1.to_i64(), Some(-1));
+        assert!(v_m1.to_f64().is_none());
+        assert!(v_m1.to_array().is_none());
+    }
+);

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gdnative-test"
+version = "0.1.0"
+workspace = ".."
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+gdnative = { path = "../gdnative", features = ["gd_test"] }

--- a/test/project/Scene.tscn
+++ b/test/project/Scene.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://main.gd" type="Script" id=1]
+
+[node name="Node" type="Node" index="0"]
+
+script = ExtResource( 1 )
+
+

--- a/test/project/gdnative.gdnlib
+++ b/test/project/gdnative.gdnlib
@@ -1,0 +1,16 @@
+[entry]
+
+X11.32="res://lib/libgdnative_test.so"
+X11.64="res://lib/libgdnative_test.so"
+Windows="res://lib/libgdnative_test.dll"
+
+[dependencies]
+
+X11.64=[  ]
+
+[general]
+
+singleton=false
+load_once=true
+symbol_prefix="godot_"
+reloadable=true

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -1,0 +1,17 @@
+extends Node
+
+func _ready():
+    print(" -- Rust gdnative test suite:")
+    var gdn = GDNative.new()
+    gdn.library = load("res://gdnative.gdnlib")
+    if gdn.initialize():
+        var status = gdn.call_native("standard_varcall", "run_tests", [])
+        gdn.terminate()
+        if status:
+            print(" -- Test run completed successfully.")
+        else:
+            print(" -- Test run completed with errors.")
+    else:
+        print(" -- Could not load the gdnative library.")
+    print(" -- exiting.")
+    get_tree().quit()

--- a/test/project/project.godot
+++ b/test/project/project.godot
@@ -1,0 +1,16 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=3
+
+[application]
+
+config/name="GodotRustTests"
+run/main_scene="res://Scene.tscn"
+
+[rendering]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,0 +1,18 @@
+#[macro_use]
+extern crate gdnative;
+
+#[no_mangle]
+pub extern "C" fn run_tests(
+    _data: *mut gdnative::libc::c_void,
+    _args: *mut gdnative::sys::godot_array
+) -> gdnative::sys::godot_variant {
+
+    let mut status = true;
+    status &= gdnative::test_string();
+    status &= gdnative::test_variant_nil();
+    status &= gdnative::test_variant_i64();
+
+    gdnative::Variant::from_bool(status).forget()
+}
+
+godot_init!();


### PR DESCRIPTION
The main idea is to write some tests in the rust code using the `godot_test` macro which generates functions that are only exported if the "gd_test" feature flag is enabled, and have a testing gdnative library call them. A simple godot app loads the library, calls `run_tests` and exits.

To try it out (on linux):

```
cd test;
cargo build
cp ../target/debug/libgdnative_test.so ./project/lib
godot --path ./project
```