### PR TITLE
Refactor build.rs

### DIFF
--- a/gdnative/src/class.rs
+++ b/gdnative/src/class.rs
@@ -1,6 +1,7 @@
 use libc;
 use sys;
 use std::ops::Deref;
+use GodotString;
 
 #[macro_export]
 #[doc(hidden)]
@@ -363,7 +364,10 @@ impl <T> GodotRef<T>
         };
         if let Some(script) = obj.get_script().and_then(|v| v.cast::<::NativeScript>()) {
             let class = script.get_class_name();
-            if class == O::godot_name() {
+            // TODO: it would be good to cache the class name as a godot string
+            // somewhere to avoid creating it every time.
+            let gd_name = GodotString::from_str(O::godot_name());
+            if class == gd_name {
                 Some(if self.reference {
                     call_bool!(self.this, Reference, reference);
                     GodotRef {

--- a/gdnative/src/generated.rs
+++ b/gdnative/src/generated.rs
@@ -4,7 +4,7 @@ use sys;
 use get_api;
 use geom::*;
 use {GodotRef, GodotClass, GodotClassInfo};
-use {Variant, VariantArray, Color, Rid, NodePath, Dictionary};
+use {Variant, VariantArray, Color, Rid, NodePath, Dictionary, GodotString};
 use {ByteArray, Int32Array, Float32Array, StringArray, Vector2Array, Vector3Array, ColorArray};
 
 use std::sync::{Once, ONCE_INIT};


### PR DESCRIPTION
This PR refactors the way we deal with types in build.rs to use an enum instead of matching strings (less error prone), and makes the generator use `GodotString` instead of rust strings to avoid the overhead of converting between the two whenever possible.