### PR TITLE
Declare property hint strings using &str instead of String.

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -30,10 +30,10 @@ godot_class! {
                     name: "test/test_enum",
                     default: godot::GodotString::from_str("Hello"),
                     hint: godot::PropertyHint::Enum {
-                        values: vec![
-                            "Hello".to_owned(),
-                            "World".to_owned(),
-                            "Testing".to_owned()
+                        values: &[
+                            "Hello",
+                            "World",
+                            "Testing",
                         ]
                     },
                     getter: |_: &mut RustTest| { godot::GodotString::from_str("Hello") },
@@ -47,12 +47,7 @@ godot_class! {
                     name: "test/test_flags",
                     default: 0,
                     hint: godot::PropertyHint::Flags {
-                        values: vec![
-                            "A".to_owned(),
-                            "B".to_owned(),
-                            "C".to_owned(),
-                            "D".to_owned()
-                        ]
+                        values: &["A", "B", "C", "D" ],
                     },
                     getter: |_: &mut RustTest| 0,
                     setter: (),

--- a/gdnative/src/property.rs
+++ b/gdnative/src/property.rs
@@ -7,7 +7,7 @@ use std::mem;
 use std::ops::Range;
 
 // TODO: missing property hints.
-pub enum PropertyHint {
+pub enum PropertyHint<'l> {
     None,
     Range {
         range: Range<f64>,
@@ -16,14 +16,14 @@ pub enum PropertyHint {
     },
     // ExpRange,
     Enum {
-        values: Vec<String>,
+        values: &'l[&'l str],
     },
     // ExpEasing,
     // Length,
     // SpriteFrame,
     // KeyAccel,
     Flags {
-        values: Vec<String>,
+        values: &'l[&'l str],
     },
     // Layers2DRender,
     // Layers2DPhysics,
@@ -51,7 +51,7 @@ pub enum PropertyHint {
     // PropertyOfScript,
 }
 
-impl PropertyHint {
+impl<'l> PropertyHint<'l> {
     fn to_sys(&self) -> sys::godot_property_hint {
         match *self {
             PropertyHint::None => GODOT_PROPERTY_HINT_NONE,
@@ -184,7 +184,7 @@ pub struct Property<'l, T, S, G>
     pub setter: S,
     pub getter: G,
     pub default: T,
-    pub hint: PropertyHint,
+    pub hint: PropertyHint<'l>,
     pub usage: PropertyUsage,
 }
 


### PR DESCRIPTION
It's a bit nicer and avoids some unnecessary heap allocations and string copies.