### PR TITLE
Set a non-zero exit code when the in engine tests fail.

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -11,6 +11,7 @@ func _ready():
             print(" -- Test run completed successfully.")
         else:
             print(" -- Test run completed with errors.")
+            OS.exit_code = 1
     else:
         print(" -- Could not load the gdnative library.")
     print(" -- exiting.")


### PR DESCRIPTION
That will make it easier to integrate these tests on the CI when we figure out how to run godot in there.