### PR TITLE
Rename libgdnative_test.dll resource path to gdnative_test.dll.

### DIFF
--- a/test/project/gdnative.gdnlib
+++ b/test/project/gdnative.gdnlib
@@ -2,7 +2,7 @@
 
 X11.32="res://lib/libgdnative_test.so"
 X11.64="res://lib/libgdnative_test.so"
-Windows="res://lib/libgdnative_test.dll"
+Windows="res://lib/gdnative_test.dll"
 
 [dependencies]
 


### PR DESCRIPTION
Since the dll generated by cargo has that name on windows.
Thanks @memoryruins for spotting this!