### PR TITLE
Fix leak when passing sys object parameters by value to godot.

### DIFF
--- a/gdnative/src/class.rs
+++ b/gdnative/src/class.rs
@@ -90,7 +90,7 @@ macro_rules! godot_class_build_export_methods {
                             return ret;
                         }
                     };
-                    <$retty as $crate::GodotType>::to_sys_variant(&rust_ret)
+                    <$retty as $crate::GodotType>::to_variant(&rust_ret).forget()
                 }
             }
             let method = $crate::sys::godot_instance_method {

--- a/gdnative/src/godot_type.rs
+++ b/gdnative/src/godot_type.rs
@@ -4,9 +4,6 @@ pub trait GodotType: Sized {
     fn to_variant(&self) -> Variant;
     fn from_variant(variant: &Variant) -> Option<Self>;
 
-    fn to_sys_variant(&self) -> sys::godot_variant {
-        self.to_variant().forget()
-    }
     fn from_sys_variant(variant: &sys::godot_variant) -> Option<Self> {
         Self::from_variant(Variant::cast_ref(variant))
     }

--- a/gdnative/src/property.rs
+++ b/gdnative/src/property.rs
@@ -140,9 +140,9 @@ impl<C: GodotClass> PropertyBuilder<C> {
                 rset_type: sys::godot_method_rpc_mode::GODOT_METHOD_RPC_MODE_DISABLED, // TODO:
                 type_: mem::transmute(ty),
                 hint: property.hint.to_sys(),
-                hint_string: hint_string.forget(),
+                hint_string: hint_string.to_sys(),
                 usage: property.usage.to_sys(),
-                default_value: default.forget(),
+                default_value: default.to_sys(),
             };
 
             let path = ::std::ffi::CString::new(property.name).unwrap();
@@ -163,11 +163,12 @@ impl<C: GodotClass> PropertyBuilder<C> {
         use std::ptr;
         unsafe {
             let api = get_api();
+            let name = GodotString::from_str(signal.name);
             (api.godot_nativescript_register_signal)(
                 self.desc,
                 self.class_name,
                 &sys::godot_signal {
-                    name: GodotString::from_str(signal.name).forget(),
+                    name: name.to_sys(),
                     num_args: 0,
                     args: ptr::null_mut(),
                     num_default_args: 0,

--- a/gdnative/src/string.rs
+++ b/gdnative/src/string.rs
@@ -166,10 +166,24 @@ impl GodotString {
         }
     }
 
+    /// Returns the internal ffi representation of the string and consumes
+    /// the rust object without running the destructor.
+    ///
+    /// This should be only used when certain that the receiving side is
+    /// responsible for running the destructor for the object, otherwise
+    /// it is leaked.
     pub fn forget(self) -> sys::godot_string {
         let v = self.0;
         forget(self);
         v
+    }
+
+    /// Returns a copy of the internal ffi representation of the string.
+    ///
+    /// The string remains owned by the rust wrapper and the receiver of
+    /// the ffi representation should not run its destructor.
+    pub fn to_sys(&self) -> sys::godot_string {
+        self.0
     }
 
     // TODO: many missing methods.

--- a/gdnative/src/variant.rs
+++ b/gdnative/src/variant.rs
@@ -494,10 +494,24 @@ impl Variant {
         unsafe { transmute(ptr) }
     }
 
+    /// Returns the internal ffi representation of the variant and consumes
+    /// the rust object without running the destructor.
+    ///
+    /// This should be only used when certain that the receiving side is
+    /// responsible for running the destructor for the object, otherwise
+    /// it is leaked.
     pub fn forget(self) -> sys::godot_variant {
         let v = self.0;
         forget(self);
         v
+    }
+
+    /// Returns a copy of the internal ffi representation of the variant.
+    ///
+    /// The variant remains owned by the rust wrapper and the receiver of
+    /// the ffi representation should not run its destructor.
+    pub fn to_sys(&self) -> sys::godot_variant {
+        self.0
     }
 }
 


### PR DESCRIPTION
Passing objects by value rather than pointer to godot in function arguments doesn't actually mean passing ownership of the value.
