### PR TITLE
Exit in-egnine tests with non-zero status when failing to find the shared lib.

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -3,16 +3,21 @@ extends Node
 func _ready():
     print(" -- Rust gdnative test suite:")
     var gdn = GDNative.new()
+    var status = false;
+
     gdn.library = load("res://gdnative.gdnlib")
+
     if gdn.initialize():
-        var status = gdn.call_native("standard_varcall", "run_tests", [])
+        status = gdn.call_native("standard_varcall", "run_tests", [])
         gdn.terminate()
-        if status:
-            print(" -- Test run completed successfully.")
-        else:
-            print(" -- Test run completed with errors.")
-            OS.exit_code = 1
     else:
         print(" -- Could not load the gdnative library.")
+
+    if status:
+        print(" -- Test run completed successfully.")
+    else:
+        print(" -- Test run completed with errors.")
+        OS.exit_code = 1
+
     print(" -- exiting.")
     get_tree().quit()


### PR DESCRIPTION
Right now the test suite exits with non-zero status if the tests fail but not if they are not run because the shared library was not found.

See #63.
