### PR TITLE
Automate testing with pre-commit script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *.rlib
 **/Cargo.lock
 .vscode
+test/project/lib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,17 @@ godot --path ./project
 
 The `godot` command in the above snippet is your local installation of godot and may vary depending on how it was installed.
 
+### Automating tests
+
+If you are on a bash-compatible system, you can use the `pre-commit.sh` to automatically run your tests every time you try to commit code.  You can install it with:
+
+```sh
+$ ln -s ../../hooks/pre-commit.sh .git/hooks/pre-commit
+$ chmod +x .git/hooks/pre-commit
+```
+
+If you don't need to run tests on your commit, you can simply run `git commit --no-verify` to skip the pre-commit script.  The pre-commit script handles a few edge cases as well, by stashing all of your changes before running tests, just in case your unstashed changes mask errors in the bare commit.  This is especially useful if you've stopped working on something to make a quick patch.
+
 ## Writing tests
 
 Some types can only be used if the engine is running, in order to test them, use the `godot_test!` macro (see examples in [variant.rs](gdnative/src/variant.rs)), and explicitly invoke the test functions in [test/src/lib.rs](test/src/lib.rs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Have a look at the [issues](https://github.com/GodotNativeTools/godot-rust/issue
 ```
 cd test
 cargo build
-cp ../target/debug/libgdnative_test.so ./project/lib
+cp ../target/debug/libgdnative_test.so ./project/lib/
 godot --path ./project
 ```
 

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+# pre-commit.sh
+
+STASH_NAME="pre-commit-$(date +%s)"
+BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# Check if commit is on a rebase, if not proceed as usual
+if [ $BRANCH_NAME != '(no branch)' ]
+then
+    stash=0
+    # Check to make sure commit isn't emtpy, exit with status 1 if it is
+    if git diff-index --quiet HEAD --; then
+        echo "${RED}You've tried to commit an empty commit${NC}"
+        echo "\tMake sure to add your changes with 'git add'"
+        exit 1
+    else
+        # Stash all changes in the working directory so we test only commit files
+        if git stash save -u -k -q $STASH_NAME; then
+            echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
+            stash=1
+        fi
+    fi
+
+    echo "${GREEN} Testing commit${NC}\n\n"
+
+    echo "${YELLOW}${BOLD}Cargo Test${NC}\n"
+    cargo test --all &&
+    cargo doc --no-deps
+
+    cargo_pass=$?
+
+    echo "\n\n${YELLOW}${BOLD}Godot Test${NC}\n"
+
+    cargo build --manifest-path ./test/Cargo.toml &&
+    mkdir -p ./test/project/lib &&
+    cp ./target/debug/libgdnative_test.so ./test/project/lib/libgdnative_test.so &&
+    godot --path ./test/project
+
+    # Capture exit code from tests
+    godot_pass=$?
+
+    # Revert stash if changes were stashed to restor working directory files
+    if [ "$stash" -eq 1 ]
+    then
+        if git stash pop -q; then
+            echo "\n\n${GREEN}Reverted stash command${NC}"
+        else
+            echo "\n\n${RED}Unable to revert stash command${NC}"
+        fi
+    fi
+    # Inform user of build failure
+    if [ "$cargo_pass" -ne "0" ]
+    then
+        echo "${RED}Build failed: cargo tests failed ${NC} if you still want to commit use ${BOLD}'--no-verify'${NC}"
+    fi
+
+    # Inform user of build failure
+    if [ "$godot_pass" -ne "0" ]
+    then
+        echo "${RED}Build failed, integration tests failed:${NC} if you still want to commit use ${BOLD}'--no-verify'${NC}"
+    fi
+
+    # Exit with exit code from tests, so if they fail, prevent commit
+    exit "$(($cargo_pass || $godot_pass))"
+else
+    # Tests were skipped for rebase, inform user and exit zero
+    echo "${YELLOW}Skipping tests on branchless commit${NC}"
+    exit 0
+fi


### PR DESCRIPTION
Solves #63.

Currently, running the integration tests against Godot is a multi-step, manual process:

```
cd test
cargo build
cp ../target/debug/libgdnative_test.so ./project/lib/
godot --path ./project
```
_from [`CONTRIBUTING.md`]_

We can improve upon this using a [git hook] which runs on every commit.  This provides a couple key advantages:

- automatically run tests, increasing the likeliness that developers will run them
- handle edge cases by stashing upstaged changes and testing the bare commit

This hook is adapted from the pre-commit hook I wrote for the [amethyst] project.

[`CONTRIBUTING.md`]: https://github.com/GodotNativeTools/godot-rust/blob/master/CONTRIBUTING.md
[git hook]: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
[amethyst]: https://github.com/amethyst/amethyst