### PR TITLE
Remove ambiguous Clone impls and add new_ref.

### DIFF
--- a/gdnative/src/byte_array.rs
+++ b/gdnative/src/byte_array.rs
@@ -4,7 +4,7 @@ use Variant;
 use GodotType;
 use VariantArray;
 
-/// A vector of bytes that uses Godot's pool allocator.
+/// A reference-counted vector of bytes that uses Godot's pool allocator.
 pub struct ByteArray(pub(crate) sys::godot_pool_byte_array);
 
 impl ByteArray {
@@ -86,12 +86,16 @@ impl ByteArray {
             (get_api().godot_pool_byte_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(& self) -> ByteArray : godot_pool_byte_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for ByteArray as godot_pool_byte_array {
         Drop => godot_pool_byte_array_destroy;
-        Clone => godot_pool_byte_array_new_copy;
         Default => godot_pool_byte_array_new;
     }
 );

--- a/gdnative/src/color_array.rs
+++ b/gdnative/src/color_array.rs
@@ -7,7 +7,7 @@ use Color;
 
 use std::mem::transmute;
 
-/// A vector of `ColorArray` that uses Godot's pool allocator.
+/// A reference-counted vector of `ColorArray` that uses Godot's pool allocator.
 pub struct ColorArray(pub(crate) sys::godot_pool_color_array);
 
 impl ColorArray {
@@ -89,12 +89,16 @@ impl ColorArray {
             (get_api().godot_pool_color_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> ColorArray : godot_pool_color_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for ColorArray as godot_pool_color_array {
         Drop => godot_pool_color_array_destroy;
-        Clone => godot_pool_color_array_new_copy;
         Default => godot_pool_color_array_new;
     }
 );

--- a/gdnative/src/dictionary.rs
+++ b/gdnative/src/dictionary.rs
@@ -6,7 +6,7 @@ use GodotString;
 use GodotType;
 use std::fmt;
 
-/// A `Dictionary` of `Variant` key-value pairs.
+/// A reference-counted `Dictionary` of `Variant` key-value pairs.
 pub struct Dictionary(pub(crate) sys::godot_dictionary);
 
 impl Dictionary {
@@ -116,12 +116,16 @@ impl Dictionary {
             (get_api().godot_dictionary_hash)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this dictionary.
+        pub fn new_ref(&self) -> Dictionary : godot_dictionary_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for Dictionary as godot_dictionary {
         Drop => godot_dictionary_destroy;
-        Clone => godot_dictionary_new_copy;
         Default => godot_dictionary_new;
         Eq => godot_dictionary_operator_equal;
     }
@@ -170,10 +174,10 @@ godot_test!(test_dictionary {
     let variant = Variant::from_dictionary(&dict);
     assert!(variant.get_type() == VariantType::Dictionary);
 
-    let dict_clone = dict.clone();
-    assert!(dict == dict_clone);
-    assert!(dict_clone.contains(&foo));
-    assert!(dict_clone.contains(&bar));
+    let dict2 = dict.new_ref();
+    assert!(dict == dict2);
+    assert!(dict2.contains(&foo));
+    assert!(dict2.contains(&bar));
 
     if let Some(dic_variant) = variant.try_to_dictionary() {
         assert!(dic_variant == dict);

--- a/gdnative/src/float32_array.rs
+++ b/gdnative/src/float32_array.rs
@@ -4,7 +4,7 @@ use Variant;
 use GodotType;
 use VariantArray;
 
-/// A vector of `f32` that uses Godot's pool allocator.
+/// A reference-counted vector of `f32` that uses Godot's pool allocator.
 pub struct Float32Array(pub(crate) sys::godot_pool_real_array);
 
 impl Float32Array {
@@ -86,12 +86,16 @@ impl Float32Array {
             (get_api().godot_pool_real_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> Float32Array : godot_pool_real_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for Float32Array as godot_pool_real_array {
         Drop => godot_pool_real_array_destroy;
-        Clone => godot_pool_real_array_new_copy;
         Default => godot_pool_real_array_new;
     }
 );

--- a/gdnative/src/int32_array.rs
+++ b/gdnative/src/int32_array.rs
@@ -4,7 +4,7 @@ use Variant;
 use GodotType;
 use VariantArray;
 
-/// A vector of `i32` that uses Godot's pool allocator.
+/// A reference-counted vector of `i32` that uses Godot's pool allocator.
 pub struct Int32Array(pub(crate) sys::godot_pool_int_array);
 
 impl Int32Array {
@@ -86,12 +86,16 @@ impl Int32Array {
             (get_api().godot_pool_int_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(& self) -> Int32Array : godot_pool_int_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for Int32Array as godot_pool_int_array {
         Drop => godot_pool_int_array_destroy;
-        Clone => godot_pool_int_array_new_copy;
         Default => godot_pool_int_array_new;
     }
 );

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -1,3 +1,17 @@
+//! # Rust bindings for the Godot game engine
+//!
+//! ## Reference-counting and mutability
+//!
+//! All non trivially copyable godot types exposed in this crate are
+//! internally reference-counted and allow mutable aliasing.
+//! In rust parlance this means that a type such as `gdnative::ByteArray`
+//! is functionally equivalent to a `Rc<Cell<Vec<u8>>>` rather than `Vec<u8>`.
+//!
+//! Since it is easy to expect container types to allocate a copy of their content
+//! when using the `Clone` trait, most of these types do not implement `Clone` and
+//! instead provide a `new_ref(&self) -> Self` method to create references to the
+//! same collection or object.
+
 #[doc(hidden)]
 pub extern crate libc;
 #[doc(hidden)]

--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -159,6 +159,39 @@ macro_rules! impl_basic_traits {
     )
 }
 
+macro_rules! impl_common_method {
+    (
+        $(#[$attr:meta])*
+        pub fn new_ref(&self) -> $Type:ident : $gd_method:ident
+    ) => {
+        $(#[$attr])*
+        pub fn new_ref(&self) -> $Type {
+            unsafe {
+                let mut result = Default::default();
+                (get_api().$gd_method)(&mut result, &self.0);
+                $Type(result)
+            }
+        }
+    };
+}
+
+macro_rules! impl_common_methods {
+    (
+        $(
+            $(#[$attr:meta])*
+            pub fn $name:ident(&self $(,$pname:ident : $pty:ty)*) -> $Ty:ident : $gd_method:ident;
+        )*
+    ) => (
+        $(
+            $(#[$attr])*
+            impl_common_method!(
+                pub fn $name(&self $(,$pname : $pty)*) -> $Ty : $gd_method
+            );
+        )*
+    )
+}
+
+
 macro_rules! godot_test {
     ($($test_name:ident $body:block)*) => {
         $(

--- a/gdnative/src/node_path.rs
+++ b/gdnative/src/node_path.rs
@@ -5,7 +5,7 @@ use GodotString;
 use Variant;
 use std::fmt;
 
-/// A relative or absolute path in a scene tree, for use with `Node.get_node()` and similar
+/// A reference-counted relative or absolute path in a scene tree, for use with `Node.get_node()` and similar
 /// functions. It can reference a node, a resource within a node, or a property of a node or
 /// resource.
 ///
@@ -98,12 +98,16 @@ impl NodePath {
     pub fn to_string(&self) -> String {
         self.to_godot_string().to_string()
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this node path.
+        pub fn new_ref(&self) -> NodePath : godot_node_path_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for NodePath as godot_node_path {
         Drop => godot_node_path_destroy;
-        Clone => godot_node_path_new_copy;
         Eq => godot_node_path_operator_equal;
     }
 );

--- a/gdnative/src/string.rs
+++ b/gdnative/src/string.rs
@@ -11,6 +11,7 @@ use std::cmp::Ordering;
 use std::mem::{transmute, forget};
 use std::fmt;
 
+/// Godot's reference-counted string type.
 pub struct GodotString(pub(crate) sys::godot_string);
 
 macro_rules! impl_methods {
@@ -187,12 +188,16 @@ impl GodotString {
     }
 
     // TODO: many missing methods.
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> GodotString : godot_string_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for GodotString as godot_string {
         Drop => godot_string_destroy;
-        Clone => godot_string_new_copy;
         Eq => godot_string_operator_equal;
         Default => godot_string_new;
     }
@@ -331,8 +336,8 @@ godot_test!(test_string {
     let foo = GodotString::from_str("foo");
     assert_eq!(foo.len(), 3);
 
-    let foo_clone = foo.clone();
-    assert!(foo == foo_clone);
+    let foo2 = foo.new_ref();
+    assert!(foo == foo2);
 
     let variant = Variant::from_godot_string(&foo);
     assert!(variant.get_type() == VariantType::GodotString);

--- a/gdnative/src/string_array.rs
+++ b/gdnative/src/string_array.rs
@@ -87,12 +87,16 @@ impl StringArray {
             (get_api().godot_pool_string_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> StringArray : godot_pool_string_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for StringArray as godot_pool_string_array {
         Drop => godot_pool_string_array_destroy;
-        Clone => godot_pool_string_array_new_copy;
         Default => godot_pool_string_array_new;
     }
 );

--- a/gdnative/src/variant_array.rs
+++ b/gdnative/src/variant_array.rs
@@ -3,7 +3,7 @@ use get_api;
 use Variant;
 use GodotType;
 
-/// An array of `Variant`. Godot's generic array data type.
+/// A reference-counted `Variant` vector. Godot's generic array data type.
 /// Negative indices can be used to count from the right.
 pub struct VariantArray(pub(crate) sys::godot_array);
 
@@ -188,12 +188,16 @@ impl VariantArray {
     // pub fn bsearch_custom(&mut self, val: ?, obj: ?, s: ?, before: bool) -> i32 {
     //     unimplemented!();
     // }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> VariantArray : godot_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for VariantArray as godot_array {
         Drop => godot_array_destroy;
-        Clone => godot_array_new_copy;
         Default => godot_array_new;
     }
 );
@@ -259,10 +263,10 @@ godot_test!(test_array {
     array.push(&foo); // [&foo]
     array.push(&bar); // [&foo, &bar]
 
-    let array_clone = array.clone();
-    assert!(array_clone.contains(&foo));
-    assert!(array_clone.contains(&bar));
-    assert!(!array_clone.contains(&nope));
+    let array2 = array.new_ref();
+    assert!(array2.contains(&foo));
+    assert!(array2.contains(&bar));
+    assert!(!array2.contains(&nope));
 });
 
 // TODO: clear arrays without affecting clones

--- a/gdnative/src/vector2_array.rs
+++ b/gdnative/src/vector2_array.rs
@@ -7,7 +7,7 @@ use Vector2;
 
 use std::mem::transmute;
 
-/// A vector of `Vector2` that uses Godot's pool allocator.
+/// A reference-counted vector of `Vector2` that uses Godot's pool allocator.
 pub struct Vector2Array(pub(crate) sys::godot_pool_vector2_array);
 
 impl Vector2Array {
@@ -89,12 +89,16 @@ impl Vector2Array {
             (get_api().godot_pool_vector2_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> Vector2Array : godot_pool_vector2_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for Vector2Array as godot_pool_vector2_array {
         Drop => godot_pool_vector2_array_destroy;
-        Clone => godot_pool_vector2_array_new_copy;
         Default => godot_pool_vector2_array_new;
     }
 );

--- a/gdnative/src/vector3_array.rs
+++ b/gdnative/src/vector3_array.rs
@@ -7,7 +7,7 @@ use Vector3;
 
 use std::mem::transmute;
 
-/// A vector of `Vector3` that uses Godot's pool allocator.
+/// A reference-counted vector of `Vector3` that uses Godot's pool allocator.
 pub struct Vector3Array(pub(crate) sys::godot_pool_vector3_array);
 
 impl Vector3Array {
@@ -89,12 +89,16 @@ impl Vector3Array {
             (get_api().godot_pool_vector3_array_size)(&self.0)
         }
     }
+
+    impl_common_methods! {
+        /// Creates a new reference to this array.
+        pub fn new_ref(&self) -> Vector3Array : godot_pool_vector3_array_new_copy;
+    }
 }
 
 impl_basic_traits!(
     for Vector3Array as godot_pool_vector3_array {
         Drop => godot_pool_vector3_array_destroy;
-        Clone => godot_pool_vector3_array_new_copy;
         Default => godot_pool_vector3_array_new;
     }
 );


### PR DESCRIPTION
Addresses #61.

This PR removes the Clone impl for most types and adds a new_ref method which goes for a less ambiguous name.
Clone was left in Variant, because new_ref doesn't really work there for for some of the types which are inline rather than reference counted. I feel like it's less surprising for Variant than other types like ByteArray.

We might implement Clone for container types again in the future, although it's not clear what it should do. Probably a deep clone for the container (godot doesn't appear to provide a method for that but we could do it manually).