### PR TITLE
Document (non) reference counted types an marke GodotRef::free unsafe.

### DIFF
--- a/gdnative/src/class.rs
+++ b/gdnative/src/class.rs
@@ -421,11 +421,9 @@ impl <T> GodotRef<T>
         }
     }
 
-    pub fn free(mut self) {
+    pub unsafe fn free(self) {
         if !self.reference {
-            unsafe {
-                (::get_api().godot_object_destroy)(self.this)
-            }
+            (::get_api().godot_object_destroy)(self.this)
         }
     }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -36,7 +36,7 @@ fn test_constructor() -> bool {
 
     let path = Path2D::new();
     let _ = path.get_z_index();
-    path.free();
+    unsafe { path.free(); }
 
     return true;
 }


### PR DESCRIPTION
With this the generated documentation will specify which types are reference counted and which are not, with a few warnings about what it implies.