### PR TITLE
Implement method tables.

### DIFF
--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -12,6 +12,11 @@ macro_rules! godot_init {
         pub extern "C" fn godot_gdnative_init(options: *mut $crate::sys::godot_gdnative_init_options) {
             unsafe {
                 $crate::GODOT_API = Some($crate::GodotApi::from_raw((*options).api_struct));
+                let api = $crate::get_api();
+                // Force the initialization of the method table of common types. This way we can
+                // assume that if the api object is alive we can fetch the method of these types
+                // without checking for initialization.
+                $crate::ReferenceMethodTable::get(api);
             }
         }
 


### PR DESCRIPTION
Instead of performing lazy initialization of each method bind individually, group them in class method tables. This will let us optimize away a lot of the init checks in the cases where we can prove that the table has already been initialized for a given object.

for example here is the generated table for the `Reference` type:

```rust
#[doc(hidden)]
pub struct ReferenceMethodTable {
    pub class_constructor: sys::godot_class_constructor,
    pub init_ref: *mut sys::godot_method_bind,
    pub reference: *mut sys::godot_method_bind,
    pub unreference: *mut sys::godot_method_bind,

}
```

Rust being a bit strict about shared mutable state, we pay for a seq consistent atomic read every time we check for static the variable initialization (in addition to a branch). I would rather only perform this check when creating an object and then assume the table is initialized when performing method calls. For Reference::reference/unreference we can even avoid the check completely by forcing the initialization along with the api object.

I also made a few changes to the generator so that it produces code that is a bit more compact.