### PR TITLE
Make non-const generated methods take &mut self.

### DIFF
--- a/examples/misc_mesh_playground/src/lib.rs
+++ b/examples/misc_mesh_playground/src/lib.rs
@@ -65,25 +65,26 @@ godot_class! {
         }
 
         export fn _ready(&mut self) {
-            let p = self.as_parent();
-            p.set_physics_process(true);
-            self.start = p.get_translation();
+            let mut parent = self.as_parent();
+            parent.set_physics_process(true);
+            self.start = parent.get_translation();
             godot_warn!("Start: {:?}", self.start);
-            godot_warn!("Parent name: {:?}", p.get_parent()
-                .expect("Missing parent")
-                .get_name());
+            godot_warn!(
+                "Parent name: {:?}",
+                parent.get_parent().expect("Missing parent").get_name()
+            );
         }
 
         export fn _physics_process(&mut self, delta: f64) {
             use godot::{Color, SpatialMaterial, Vector3};
             self.time += delta as f32;
-            let p = self.as_parent();
-            p.rotate_y(self.rotate_speed);
+            let mut parent = self.as_parent();
+            parent.rotate_y(self.rotate_speed);
             let offset = Vector3::new(0.0, 1.0, 0.0) * self.time.cos() * 0.5;
-            p.set_translation(self.start + offset);
+            parent.set_translation(self.start + offset);
 
-            if let Some(mat) = p.get_surface_material(0) {
-                let mat = mat.cast::<SpatialMaterial>().expect("Incorrect material");
+            if let Some(mat) = parent.get_surface_material(0) {
+                let mut mat = mat.cast::<SpatialMaterial>().expect("Incorrect material");
                 mat.set_albedo(Color::rgba(self.time.cos().abs(), 0.0, 0.0, 1.0));
             }
         }

--- a/gdnative/build.rs
+++ b/gdnative/build.rs
@@ -339,6 +339,14 @@ impl Deref for {name} {{
         }}
     }}
 }}
+
+impl DerefMut for {name} {{
+    fn deref_mut(&mut self) -> &mut Self::Target {{
+        unsafe {{
+            mem::transmute(self)
+        }}
+    }}
+}}
 "#,             name = class.name,
                 parent = class.base_class
             ).unwrap();
@@ -472,9 +480,15 @@ r#"
                 params.push_str(", varargs: &[Variant]");
             }
 
+            let self_param = if method.is_const {
+                "&self"
+            } else {
+                "&mut self"
+            };
+
             writeln!(output, r#"
 
-    pub fn {name}(&self{params}) -> {rust_ret_type} {{
+    pub fn {name}({self_param}{params}) -> {rust_ret_type} {{
         unsafe {{
             let api = ::get_api();
 
@@ -483,6 +497,7 @@ r#"
                 name = method_name,
                 rust_ret_type = rust_ret_type,
                 params = params,
+                self_param = self_param,
             ).unwrap();
             if method.has_varargs {
                 writeln!(output,


### PR DESCRIPTION
This isn't very idiomatic in the sense that most godot types have mutable aliasing, so &mut self here doesn't mean unique mutable view but just that the object will be mutated.
This means `&self`/`&mut self` is just decorative since any non-mutable object can be moved into a mutable slot at any time, but it maps well to how most people reason about mutability (albeit the lie about aliasing).

Fixes #74.