### PR TITLE
Add more useful information in the generated type documentation.

### DIFF
--- a/gdnative/build.rs
+++ b/gdnative/build.rs
@@ -200,6 +200,8 @@ fn main() {
         if class.base_class != "" {
             writeln!(output,
 r#"///
+/// ## Base class
+///
 /// {name} inherits [{base_class}](struct.{base_class}.html) and all of its methods."#,
                 name = class.name,
                 base_class = class.base_class
@@ -209,15 +211,28 @@ r#"///
         if class.is_reference {
             writeln!(output,
 r#"///
-/// The lifetime of this object is automatically managed."#
+/// ## Memory management
+///
+/// The lifetime of this object is automatically managed through reference counting."#
             ).unwrap();
         } else if class.instanciable {
             writeln!(output,
 r#"///
+/// ## Memory management
+///
 /// Non reference counted objects such as the ones of this type are usually owned by the engine.
 /// In the cases where Rust code owns an object of this type, ownership should be either passed
 /// to the engine or the object must be manually destroyed using `{}::free`."#,
                 class.name
+            ).unwrap();
+        }
+
+        if class.api_type == "tools" {
+            writeln!(output,
+r#"///
+/// ## Tool
+///
+/// This class is used to interact with godot's editor."#,
             ).unwrap();
         }
 


### PR DESCRIPTION
Add some info in the generated doc about the type of API, whether the object is a singleton and what the parent class is if any. In the extended doc of the type, the parent class is a clickable link to the doc of the parent class.

![screenshot_2018-05-03 gdnative - rust 1](https://user-images.githubusercontent.com/264854/39553010-ee49630c-4e6b-11e8-94ad-d2a7e5057ea0.png)
