### PR TITLE
Remove an errant ';' breaking wrapped method return types

### DIFF
--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -407,7 +407,7 @@ macro_rules! godot_wrap_method {
                 let mut __rust_val = __rust_val.borrow_mut();
 
                 let rust_ret = match panic::catch_unwind(AssertUnwindSafe(|| {
-                    __rust_val.$method_name($($pname,)*);
+                    __rust_val.$method_name($($pname,)*)
                 })) {
                     Ok(val) => val,
                     Err(err) => {


### PR DESCRIPTION
Not much to say beyond the commit comment - the ';' was forcing the type of rust_ret to (), causing compilation to break on the later to_variant call.