### PR TITLE
Export entry points with the proper prefixes in the manually_registered example

### DIFF
--- a/examples/manually_registered/icon.png.import
+++ b/examples/manually_registered/icon.png.import
@@ -7,7 +7,10 @@ path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
 [deps]
 
 source_file="res://icon.png"
+source_md5="ae7e641067601e2184afcade49abd283"
+
 dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_md5="84511021bbc8c9d37c7f0f4d181de883"
 
 [params]
 

--- a/examples/manually_registered/src/lib.rs
+++ b/examples/manually_registered/src/lib.rs
@@ -90,7 +90,7 @@ fn init(gdnative_init: init::InitHandle) {
     class.add_method("_exit_tree", exit_tree_method);
 }
 
-godot_gdnative_init!();
-godot_nativescript_init!(init);
-godot_gdnative_terminate!();
+godot_nativescript_init!(init as godot_rust_nativescript_init);
+godot_gdnative_init!(_ as godot_rust_gdnative_init);
+godot_gdnative_terminate!(_ as godot_rust_gdnative_terminate);
 

--- a/gdnative/src/macros.rs
+++ b/gdnative/src/macros.rs
@@ -19,6 +19,10 @@ macro_rules! godot_gdnative_init {
         fn godot_gdnative_init_empty(_options: *mut $crate::sys::godot_gdnative_init_options) {}
         godot_gdnative_init!(godot_gdnative_init_empty);
     };
+    (_ as $fn_name:ident) => {
+        fn godot_gdnative_init_empty(_options: *mut $crate::sys::godot_gdnative_init_options) {}
+        godot_gdnative_init!(godot_gdnative_init_empty as $fn_name);
+    };
     ($callback:ident) => {
         godot_gdnative_init!($callback as godot_gdnative_init);
     };
@@ -62,6 +66,10 @@ macro_rules! godot_gdnative_terminate {
     ($callback:ident) => {
         godot_gdnative_terminate!($callback as godot_gdnative_terminate);
     };
+    (_ as $fn_name:ident) => {
+        fn godot_gdnative_terminate_empty(_options: *mut $crate::sys::godot_gdnative_terminate_options) {}
+        godot_gdnative_terminate!(godot_gdnative_terminate_empty as $fn_name);
+    };
     ($callback:ident as $fn_name:ident) => {
         #[no_mangle]
         #[doc(hidden)]
@@ -96,6 +104,10 @@ macro_rules! godot_nativescript_init {
     };
     ($callback:ident) => {
         godot_nativescript_init!($callback as godot_nativescript_init);
+    };
+    (_ as $fn_name:ident) => {
+        fn godot_nativescript_init_empty(_init: $crate::init::InitHandle) {}
+        godot_nativescript_init!(godot_nativescript_init_empty as $fn_name);
     };
     ($callback:ident as $fn_name:ident) => {
         #[no_mangle]


### PR DESCRIPTION
This partially solves #90 although there still seem to be an issue since it looks like the _ready function isn't called. I'll keep looking.