### PR TITLE
gdnative 0.4.0.

### DIFF
--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["The godot-rust developers"]
 description = "The Godot game engine's gdnative bindings."
 documentation = "https://docs.rs/crate/gdnative"
 repository = "https://github.com/GodotNativeTools/godot-rust"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 workspace = ".."
 


### PR DESCRIPTION
Long overdue release with the arm build fix, macro-free API to initialize classes, signal arguments and improved documentation.

https://crates.io/crates/gdnative/0.4.0