### PR TITLE
added way to initialize API struct manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .vscode
 test/project/lib
 **/.import/*
+.idea/

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ workspace = ".."
 
 [features]
 gd_test = []
+api_struct_raw_init = []
 
 [dependencies]
 gdnative-sys = { path = "../sys", version = "0.5.0" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -93,6 +93,16 @@ pub fn get_api() -> &'static GodotApi {
     unsafe { GODOT_API.as_ref().expect("API not bound") }
 }
 
+#[inline]
+#[doc(hidden)]
+#[cfg(feature = "api_struct_raw_init")]
+pub unsafe fn set_api(api_raw: *const sys::godot_gdnative_core_api_struct) {
+    GODOT_API = Some(GodotApi::from_raw(api_raw));
+
+    let api = get_api();
+    ReferenceMethodTable::get(api);
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum GodotError {

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -10,6 +10,8 @@ workspace = ".."
 
 [features]
 gd_test = ["gdnative-core/gd_test"]
+api_struct_raw_init = ["gdnative-core/api_struct_raw_init"]
+
 
 graphics = ["gdnative-graphics"]
 physics = ["gdnative-physics"]


### PR DESCRIPTION
This is useful when Rust is used inside Godot **when using static linking** and not using the NativeScript/GDNative API for loading shared libraries.

From inside Godot you have access to the static GDNative API struct, so passing it over is doable.