### PR TITLE
Enable "is_tool" option in godot_class macro

### DIFF
--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,6 +3,8 @@ extern crate gdnative as godot;
 
 godot_class! {
     class HelloWorld: godot::Node {
+        is_tool: false;
+
         fields {
         }
 

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,7 +3,7 @@ extern crate gdnative as godot;
 
 godot_class! {
     class HelloWorld: godot::Node {
-        is_tool: false;
+        //is_tool // uncomment to enable use in editor
 
         fields {
         }

--- a/examples/manually_registered/src/lib.rs
+++ b/examples/manually_registered/src/lib.rs
@@ -77,6 +77,7 @@ fn init(gdnative_init: init::InitHandle) {
         fn _exit_tree(&mut self) -> ()
     );
 
+    // swap with gdnative_init.add_tool_class to enable use in editor
     let class = gdnative_init.add_class::<MyClass>(
         ClassDescriptor {
             name: "MyClass",

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -6,6 +6,7 @@ use godot::GodotString;
 
 godot_class! {
     class RustTest: godot::MeshInstance {
+	is_tool: false;
         fields {
             start: godot::Vector3,
             time: f32,

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -6,7 +6,7 @@ use godot::GodotString;
 
 godot_class! {
     class RustTest: godot::MeshInstance {
-	is_tool: false;
+	    //is_tool // uncomment to enable use in editor
         fields {
             start: godot::Vector3,
             time: f32,


### PR DESCRIPTION
I wasn't sure if I should modify the existing godot_class macro expansion, create a second almost identical expansion or create a completely separate almost identical macro godot_tool_class. I basically flipped a coin and went the minimum duplication route. But that means it is not backwards compatible. I tried to make the is_tool statement optional, but either macros or my macro-fu were not up to the task. If you don't want to break backwards compatibility, let me know which option you prefer (new expansion or new macro) and I'll be happy to oblige.