### PR TITLE
refactor of NativeClass trait and init functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ target
 *.rlib
 **/Cargo.lock
 .vscode
+.idea
 test/project/lib
 **/.import/*

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -50,22 +50,54 @@ impl InitHandle {
     ///
     /// The return `ClassBuilder` can be used to add methods, signals and properties
     /// to the class.
-    pub fn add_class<C>(&self, desc: ClassDescriptor) -> ClassBuilder<C>
-    where C: NativeClass {
+    pub fn add_class<C>(&self)
+    where C: NativeClassRegister {
         unsafe {
-            let class_name = CString::new(desc.name).unwrap();
-            let base_name = CString::new(desc.base_class).unwrap();
+            let class_name = CString::new(C::class_name()).unwrap();
+            let base_name = CString::new(C::Base::class_name()).unwrap();
 
-            let create = sys::godot_instance_create_func {
-                create_func: desc.constructor,
-                method_data: ptr::null_mut(),
-                free_func: None,
+
+            let create = {
+                unsafe extern "C" fn constructor<C: NativeClass>(
+                    this: *mut sys::godot_object,
+                    _method_data: *mut libc::c_void
+                ) -> *mut libc::c_void {
+                    use std::cell::RefCell;
+                    use std::boxed::Box;
+
+                    use crate::GodotObject;
+
+                    let val = C::init(C::Base::from_sys(this));
+
+                    let wrapper = Box::new(RefCell::new(val));
+                    Box::into_raw(wrapper) as *mut _
+                }
+
+                sys::godot_instance_create_func {
+                    create_func: Some(constructor::<C>),
+                    method_data: ptr::null_mut(),
+                    free_func: None,
+                }
             };
 
-            let destroy = sys::godot_instance_destroy_func {
-                destroy_func: desc.destructor,
-                method_data: ptr::null_mut(),
-                free_func: None,
+            let destroy = {
+                unsafe extern "C" fn destructor<C: NativeClass>(
+                    _this: *mut sys::godot_object,
+                    _method_data: *mut libc::c_void,
+                    user_data: *mut libc::c_void
+                ) -> () {
+                    use std::cell::RefCell;
+                    use std::boxed::Box;
+
+                    let wrapper: Box<RefCell<C>> = Box::from_raw(user_data as *mut _);
+                    drop(wrapper)
+                }
+
+                sys::godot_instance_destroy_func {
+                    destroy_func: Some(destructor::<C>),
+                    method_data: ptr::null_mut(),
+                    free_func: None,
+                }
             };
 
             (get_api().godot_nativescript_register_class)(
@@ -76,11 +108,13 @@ impl InitHandle {
                 destroy
             );
 
-            ClassBuilder {
+            let builder = ClassBuilder {
                 init_handle: self.handle,
                 class_name,
                 _marker: PhantomData,
-            }
+            };
+
+            C::register(builder);
         }
     }
 
@@ -88,22 +122,54 @@ impl InitHandle {
     ///
     /// The return `ClassBuilder` can be used to add methods, signals and properties
     /// to the class.
-    pub fn add_tool_class<C>(&self, desc: ClassDescriptor) -> ClassBuilder<C>
-    where C: NativeClass {
+    pub fn add_tool_class<C>(&self)
+        where C: NativeClassRegister {
         unsafe {
-            let class_name = CString::new(desc.name).unwrap();
-            let base_name = CString::new(desc.base_class).unwrap();
+            let class_name = CString::new(C::class_name()).unwrap();
+            let base_name = CString::new(C::Base::class_name()).unwrap();
 
-            let create = sys::godot_instance_create_func {
-                create_func: desc.constructor,
-                method_data: ptr::null_mut(),
-                free_func: None,
+
+            let create = {
+                unsafe extern "C" fn constructor<C: NativeClass>(
+                    this: *mut sys::godot_object,
+                    _method_data: *mut libc::c_void
+                ) -> *mut libc::c_void {
+                    use std::cell::RefCell;
+                    use std::boxed::Box;
+
+                    use crate::GodotObject;
+
+                    let val = C::init(C::Base::from_sys(this));
+
+                    let wrapper = Box::new(RefCell::new(val));
+                    Box::into_raw(wrapper) as *mut _
+                }
+
+                sys::godot_instance_create_func {
+                    create_func: Some(constructor::<C>),
+                    method_data: ptr::null_mut(),
+                    free_func: None,
+                }
             };
 
-            let destroy = sys::godot_instance_destroy_func {
-                destroy_func: desc.destructor,
-                method_data: ptr::null_mut(),
-                free_func: None,
+            let destroy = {
+                unsafe extern "C" fn destructor<C: NativeClass>(
+                    _this: *mut sys::godot_object,
+                    _method_data: *mut libc::c_void,
+                    user_data: *mut libc::c_void
+                ) -> () {
+                    use std::cell::RefCell;
+                    use std::boxed::Box;
+
+                    let wrapper: Box<RefCell<C>> = Box::from_raw(user_data as *mut _);
+                    drop(wrapper)
+                }
+
+                sys::godot_instance_destroy_func {
+                    destroy_func: Some(destructor::<C>),
+                    method_data: ptr::null_mut(),
+                    free_func: None,
+                }
             };
 
             (get_api().godot_nativescript_register_tool_class)(
@@ -114,11 +180,13 @@ impl InitHandle {
                 destroy
             );
 
-            ClassBuilder {
+            let builder = ClassBuilder {
                 init_handle: self.handle,
                 class_name,
                 _marker: PhantomData,
-            }
+            };
+
+            C::register(builder);
         }
     }
 }

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -51,7 +51,7 @@ impl InitHandle {
     /// The return `ClassBuilder` can be used to add methods, signals and properties
     /// to the class.
     pub fn add_class<C>(&self)
-    where C: NativeClassRegister {
+    where C: NativeClassMethods {
         unsafe {
             let class_name = CString::new(C::class_name()).unwrap();
             let base_name = CString::new(C::Base::class_name()).unwrap();
@@ -108,13 +108,16 @@ impl InitHandle {
                 destroy
             );
 
-            let builder = ClassBuilder {
+            let mut builder = ClassBuilder {
                 init_handle: self.handle,
                 class_name,
                 _marker: PhantomData,
             };
 
-            C::register(builder);
+            C::register_properties(&mut builder);
+
+            // register methods
+            C::register(&mut builder);
         }
     }
 
@@ -123,7 +126,7 @@ impl InitHandle {
     /// The return `ClassBuilder` can be used to add methods, signals and properties
     /// to the class.
     pub fn add_tool_class<C>(&self)
-        where C: NativeClassRegister {
+        where C: NativeClassMethods {
         unsafe {
             let class_name = CString::new(C::class_name()).unwrap();
             let base_name = CString::new(C::Base::class_name()).unwrap();
@@ -180,13 +183,16 @@ impl InitHandle {
                 destroy
             );
 
-            let builder = ClassBuilder {
+            let mut builder = ClassBuilder {
                 init_handle: self.handle,
                 class_name,
                 _marker: PhantomData,
             };
 
-            C::register(builder);
+            C::register_properties(&mut builder);
+
+            // register methods
+            C::register(&mut builder);
         }
     }
 }

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,7 +3,6 @@ extern crate gdnative as godot;
 
 godot_class! {
     class HelloWorld: godot::Node {
-        //is_tool // uncomment to enable use in editor
 
         fields {
         }
@@ -11,20 +10,19 @@ godot_class! {
         setup(_builder) {
         }
 
-        constructor(header) {
+        constructor(_owner: godot::Node) {
             HelloWorld {
-                header,
             }
         }
 
-        export fn _ready(&mut self) {
+        export fn _ready(&mut self, _owner: godot::Node) {
             godot_print!("hello, world.");
         }
     }
 }
 
 fn init(handle: godot::init::InitHandle) {
-    HelloWorld::register_class(handle);
+    handle.add_class::<HelloWorld>();
 }
 
 godot_gdnative_init!();

--- a/examples/manually_registered/src/lib.rs
+++ b/examples/manually_registered/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate gdnative as godot;
 
 use godot::*;
@@ -48,8 +47,8 @@ impl NativeClass for MyClass {
     }
 }
 
-impl NativeClassRegister for MyClass {
-    fn register(builder: godot::init::ClassBuilder<Self>) {
+impl NativeClassMethods for MyClass {
+    fn register(builder: &godot::init::ClassBuilder<Self>) {
 
         use godot::init::*;
 
@@ -85,8 +84,6 @@ impl NativeClassRegister for MyClass {
 }
 
 fn init(gdnative_init: init::InitHandle) {
-    use godot::init::*;
-
     gdnative_init.add_class::<MyClass>();
 }
 

--- a/examples/manually_registered/src/lib.rs
+++ b/examples/manually_registered/src/lib.rs
@@ -4,31 +4,25 @@ extern crate gdnative as godot;
 use godot::*;
 
 struct MyClass {
-    // This field is usually needed in order to call methods of the parent
-    // class, but in this specific case this never happens, so this field
-    // is actually not needed here. 99% of the time you usually need this.
-    header: NativeInstanceHeader,
-
     elapsed_time: f64,
 }
 
 impl MyClass {
-    fn new(header: NativeInstanceHeader) -> Self {
+    fn new() -> Self {
         MyClass {
-            header: header,
             elapsed_time: 0.0,
         }
     }
 
-    fn _ready(&mut self) {
+    fn _ready(&mut self, _: Node) {
         godot_print!("Hello World!");
     }
 
-    fn _process(&mut self, delta: f64) {
+    fn _process(&mut self, _: Node, delta: f64) {
         self.elapsed_time += delta;
     }
 
-    fn _exit_tree(&mut self) {
+    fn _exit_tree(&mut self, _: Node) {
         godot_print!(
             "MyClass node was running for {} seconds",
             self.elapsed_time
@@ -36,59 +30,64 @@ impl MyClass {
     }
 }
 
+impl Default for MyClass {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NativeClass for MyClass {
+    type Base = Node;
+
     fn class_name() -> &'static str {
         "MyClass"
     }
 
-    fn get_header(&self) -> &NativeInstanceHeader {
-        &self.header
+    fn init(_owner: Node) -> Self {
+        MyClass::new()
+    }
+}
+
+impl NativeClassRegister for MyClass {
+    fn register(builder: godot::init::ClassBuilder<Self>) {
+
+        use godot::init::*;
+
+        let ready_method = godot_wrap_method!(
+            MyClass,
+            fn _ready(&mut self, _owner: Node) -> ()
+        );
+
+        let ready_method = ScriptMethod {
+            name: "_ready",
+            method_ptr: Some(ready_method),
+            attributes: ScriptMethodAttributes {
+                rpc_mode: RpcMode::Disabled
+            },
+            method_data: std::ptr::null_mut(),
+            free_func: None
+        };
+
+        let process_method = godot_wrap_method!(
+            MyClass,
+            fn _process(&mut self, _owner: Node, delta: f64) -> ()
+        );
+
+        let exit_tree_method = godot_wrap_method!(
+            MyClass,
+            fn _exit_tree(&mut self, _owner: Node) -> ()
+        );
+
+        builder.add_method_advanced(ready_method);
+        builder.add_method("_process", process_method);
+        builder.add_method("_exit_tree", exit_tree_method);
     }
 }
 
 fn init(gdnative_init: init::InitHandle) {
     use godot::init::*;
 
-    let constructor = godot_wrap_constructor!(MyClass, MyClass::new);
-    let destructor  = godot_wrap_destructor!(MyClass);
-
-    let ready_method = godot_wrap_method!(
-        MyClass,
-        fn _ready(&mut self) -> ()
-    );
-
-    let ready_method = ScriptMethod {
-        name: "_ready",
-        method_ptr: Some(ready_method),
-        attributes: ScriptMethodAttributes {
-            rpc_mode: RpcMode::Disabled
-        },
-        method_data: std::ptr::null_mut(),
-        free_func: None
-    };
-
-    let process_method = godot_wrap_method!(
-        MyClass,
-        fn _process(&mut self, delta: f64) -> ()
-    );
-
-    let exit_tree_method = godot_wrap_method!(
-        MyClass,
-        fn _exit_tree(&mut self) -> ()
-    );
-
-    // swap with gdnative_init.add_tool_class to enable use in editor
-    let class = gdnative_init.add_class::<MyClass>(
-        ClassDescriptor {
-            name: "MyClass",
-            base_class: "Node",
-            constructor: Some(constructor),
-            destructor: Some(destructor),
-        }
-    );
-    class.add_method_advanced(ready_method);
-    class.add_method("_process", process_method);
-    class.add_method("_exit_tree", exit_tree_method);
+    gdnative_init.add_class::<MyClass>();
 }
 
 godot_nativescript_init!(init as godot_rust_nativescript_init);

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -58,18 +58,17 @@ godot_class! {
                 }
             );
         }
-        constructor(header) {
+        constructor(_owner: godot::MeshInstance) {
             RustTest {
-                header,
                 start: godot::Vector3::new(0.0, 0.0, 0.0),
                 time: 0.0,
                 rotate_speed: 0.05,
             }
         }
 
-        export fn _ready(&mut self) {
+        export fn _ready(&mut self, owner: godot::MeshInstance) {
             unsafe {
-                let mut owner = self.get_owner();
+                let mut owner = owner;
                 owner.set_physics_process(true);
                 self.start = owner.get_translation();
                 godot_warn!("Start: {:?}", self.start);
@@ -80,11 +79,11 @@ godot_class! {
             }
         }
 
-        export fn _physics_process(&mut self, delta: f64) {
+        export fn _physics_process(&mut self, owner: godot::MeshInstance, delta: f64) {
             use godot::{Color, Vector3, SpatialMaterial};
             unsafe {
                 self.time += delta as f32;
-                let mut owner = self.get_owner();
+                let mut owner = owner;
                 owner.rotate_y(self.rotate_speed);
                 let offset = Vector3::new(0.0, 1.0, 0.0) * self.time.cos() * 0.5;
                 owner.set_translation(self.start + offset);
@@ -99,7 +98,7 @@ godot_class! {
 }
 
 fn init(handle: godot::init::InitHandle) {
-    RustTest::register_class(handle);
+    handle.add_class::<RustTest>();
 }
 
 godot_gdnative_init!();


### PR DESCRIPTION
Now all the needed information to register a class
to Godot is provided via trait implementations.

This is needed for implementing automation of binding-code generation
using procedural macros (or regular macros) properly without "mystifying"
the original written source code.

Another change along this is that the "owner" pointer is now no longer
only passed in the "constructor" in form of an opaque handle, but instead
the owning Godot-object has to be passed as a first parameter to every
function.

Next step for me is to finish implementing a procedural macro which will generate the `NativeClass` and `NativeClassRegister` implementations automatically.