### PR TITLE
Implement ToVariant for bool, and for Variant using Clone.

### DIFF
--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -845,3 +845,13 @@ impl ToVariant for String {
         }
     }
 }
+
+impl ToVariant for Variant {
+    fn to_variant(&self) -> Variant {
+        self.clone()
+    }
+
+    fn from_variant(variant: &Variant) -> Option<Self> {
+        Some(variant.clone())
+    }
+}

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -846,6 +846,16 @@ impl ToVariant for String {
     }
 }
 
+impl ToVariant for bool {
+    fn to_variant(&self) -> Variant {
+        Variant::from_bool(*self)
+    }
+
+    fn from_variant(variant: &Variant) -> Option<Self> {
+        variant.try_to_bool()
+    }
+}
+
 impl ToVariant for Variant {
     fn to_variant(&self) -> Variant {
         self.clone()


### PR DESCRIPTION
This allows exporting functions that take or return bools and Variants using the macros.