### PR TITLE
Fix null function pointer due to renaming of "new"

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -105,15 +105,27 @@ pub struct GodotMethod {
     pub arguments: Vec<GodotArgument>,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct MethodName<'a> {
+    pub rust_name: &'a str,
+    pub original_name: &'a str,
+}
+
 impl GodotMethod {
-    pub fn get_name(&self) -> &str {
+    pub fn get_name(&self) -> MethodName {
         // GDScript and NativeScript have ::new methods but we want to reserve
         // the name for the constructors.
         if &self.name == "new" {
-            return "_new";
+            return MethodName {
+                rust_name: "_new",
+                original_name: "new",
+            };
         }
 
-        &self.name
+        MethodName {
+            rust_name: &self.name,
+            original_name: &self.name,
+        }
     }
 
     pub fn get_return_type(&self) -> Ty {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -22,6 +22,7 @@ pub extern "C" fn run_tests(
     status &= gdnative::test_vector3_variants();
 
     status &= test_constructor();
+    status &= test_underscore_method_binding();
 
     gdnative::Variant::from_bool(status).forget()
 }
@@ -42,6 +43,21 @@ fn test_constructor() -> bool {
     }
 
     return true;
+}
+
+fn test_underscore_method_binding() -> bool {
+    println!(" -- test_underscore_method_binding");
+
+    let ok = std::panic::catch_unwind(|| {
+        let table = gdnative::NativeScriptMethodTable::get(get_api());
+        assert_ne!(0, table._new as usize);
+    }).is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_underscore_method_binding failed");
+    }
+
+    ok
 }
 
 godot_gdnative_init!();


### PR DESCRIPTION
Previously, when the binding generator renamed "new" to "_new", the original name is forgotten, and "_new" is used as an argument to `godot_method_bind_get_method`, leading to null function pointer for that method.

This fixes the problem, and makes it harder for further renamings to cause similiar bugs.