### PR TITLE
Construct object from custom native class

### DIFF
--- a/bindings_generator/api.json
+++ b/bindings_generator/api.json
@@ -150414,7 +150414,7 @@
 			},
 			{
 				"name": "new",
-				"return_type": "Object",
+				"return_type": "Variant",
 				"is_editor": false,
 				"is_noscript": false,
 				"is_const": false,

--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -106,6 +106,10 @@ fn generate_class_bindings(
             generate_singleton_getter(output_types_impls, class)?;
         }
 
+        if class.name == "GDNativeLibrary" {
+            generate_gdnative_library_singleton_getter(output_types_impls, class)?;
+        }
+
         if class.instanciable {
             if class.is_refcounted() {
                 generate_reference_ctor(output_types_impls, class)?;
@@ -157,6 +161,10 @@ fn generate_class_bindings(
 
         if class.is_refcounted() && class.instanciable {
             generate_drop(output_trait_impls, class)?;
+        }
+
+        if class.instanciable {
+            generate_instanciable_impl(output_trait_impls, class)?;
         }
     }
 

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -112,7 +112,24 @@ impl FromVariant for {name} {{
             "object::add_ref(obj);"
         } else {
             "// Not reference-counted."
-        }
+        },
+    )?;
+
+    Ok(())
+}
+
+pub fn generate_instanciable_impl(output: &mut impl Write, class: &GodotClass) -> GeneratorResult {
+    assert!(class.instanciable);
+    
+    writeln!(
+        output,
+        r#"
+impl Instanciable for {name} {{
+    fn construct() -> Self {{
+        {name}::new()
+    }}
+}}"#,
+        name = class.name,
     )?;
 
     Ok(())
@@ -301,6 +318,27 @@ impl Drop for {name} {{
     }}
 }}"#,
         name = class.name
+    )?;
+
+    Ok(())
+}
+
+pub fn generate_gdnative_library_singleton_getter(output: &mut impl Write, class: &GodotClass) -> GeneratorResult {
+    assert_eq!("GDNativeLibrary", class.name);
+    writeln!(
+        output,
+        r#"
+/// Returns the GDNativeLibrary object of this library. Can be used to construct NativeScript objects.
+/// 
+/// See also `Instance::new` for a typed API.
+#[inline]
+pub fn current_library() -> Self {{
+    let this = get_gdnative_library_sys();
+
+    Self {{
+        this
+    }}
+}}"#
     )?;
 
     Ok(())

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,6 +3,7 @@ extern crate gdnative;
 
 #[derive(gdnative::NativeClass)]
 #[inherit(gdnative::Node)]
+#[user_data(gdnative::user_data::ArcData<HelloWorld>)]
 struct HelloWorld;
 
 #[gdnative::methods]

--- a/examples/scene_create/src/lib.rs
+++ b/examples/scene_create/src/lib.rs
@@ -19,6 +19,9 @@ struct SceneCreate {
     children_spawned: u32,
 }
 
+// Assume godot objects are safe to Send
+unsafe impl Send for SceneCreate { }
+
 // Demonstrates Scene creation, calling to/from gdscript
 //
 //   1. Child scene is created when spawn_one is called

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -12,6 +12,7 @@ struct RustTest {
 
 impl godot::NativeClass for RustTest {
     type Base = godot::MeshInstance;
+    type UserData = godot::user_data::MutexData<RustTest>;
 
     fn class_name() -> &'static str {
         "RustTest"
@@ -30,7 +31,7 @@ impl godot::NativeClass for RustTest {
                 step: 0.01,
                 slider: true,
             },
-            getter: |this: &mut RustTest| this.rotate_speed,
+            getter: |this: &RustTest| this.rotate_speed,
             setter: |this: &mut RustTest, v| this.rotate_speed = v,
             usage: PropertyUsage::DEFAULT,
         });
@@ -41,7 +42,7 @@ impl godot::NativeClass for RustTest {
             hint: PropertyHint::Enum {
                 values: &["Hello", "World", "Testing"],
             },
-            getter: |_: &mut RustTest| GodotString::from_str("Hello"),
+            getter: |_: &RustTest| GodotString::from_str("Hello"),
             setter: (),
             usage: PropertyUsage::DEFAULT,
         });
@@ -52,7 +53,7 @@ impl godot::NativeClass for RustTest {
             hint: PropertyHint::Flags {
                 values: &["A", "B", "C", "D"],
             },
-            getter: |_: &mut RustTest| 0,
+            getter: |_: &RustTest| 0,
             setter: (),
             usage: PropertyUsage::DEFAULT,
         });

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -17,6 +17,7 @@ gdnative-sys = { path = "../gdnative-sys", version = "0.5.0" }
 libc = "0.2"
 bitflags = "1.0"
 euclid = "0.19.6"
+parking_lot = "0.9.0"
 
 [build-dependencies]
 gdnative_bindings_generator = { path = "../bindings_generator", version = "0.2.0" }

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -155,8 +155,18 @@ impl<T: NativeClass> Instance<T> {
     }
 
     /// Calls a function with a NativeClass instance and its owner, and returns its return
-    /// value. Can be used for multiple times via aliasing. For reference-counted types
-    /// behaves like the safe `map`, which should be preferred.
+    /// value. Can be used for multiple times via aliasing:
+    /// 
+    /// ```ignore
+    /// unsafe {
+    ///     instance.map_aliased(/* ... */);
+    ///     // instance.owner may be invalid now, but you can still:
+    ///     instance.map_aliased(/* ... */);
+    ///     instance.map_aliased(/* ... */); // ...for multiple times
+    /// }
+    /// ```
+    /// 
+    /// For reference-counted types behaves like the safe `map`, which should be preferred.
     pub unsafe fn map_aliased<F, U>(&self, op: F) -> Result<U, <T::UserData as Map>::Err>
     where
         T::UserData: Map,
@@ -166,8 +176,18 @@ impl<T: NativeClass> Instance<T> {
     }
 
     /// Calls a function with a NativeClass instance and its owner, and returns its return
-    /// value. Can be used for multiple times via aliasing. For reference-counted types
-    /// behaves like the safe `map`, which should be preferred.
+    /// value. Can be used for multiple times via aliasing:
+    /// 
+    /// ```ignore
+    /// unsafe {
+    ///     instance.map_mut_aliased(/* ... */);
+    ///     // instance.owner may be invalid now, but you can still:
+    ///     instance.map_mut_aliased(/* ... */);
+    ///     instance.map_mut_aliased(/* ... */); // ...for multiple times
+    /// }
+    /// ```
+    /// 
+    /// For reference-counted types behaves like the safe `map_mut`, which should be preferred.
     pub unsafe fn map_mut_aliased<F, U>(&self, op: F) -> Result<U, <T::UserData as MapMut>::Err>
     where
         T::UserData: MapMut,

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -1,10 +1,12 @@
 use crate::get_api;
-use crate::object;
 use crate::sys;
+use crate::object;
+use crate::Variant;
+use crate::ToVariant;
+use crate::GodotString;
 use crate::GodotObject;
+use crate::Instanciable;
 use std::cell::RefCell;
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 /// Trait used for describing and initializing a Godot script class.
 ///
@@ -60,71 +62,116 @@ pub trait NativeClassMethods: NativeClass {
     fn register(builder: &crate::init::ClassBuilder<Self>);
 }
 
-/// A reference to a rust native script.
-pub struct NativeRef<T: NativeClass> {
-    this: *mut sys::godot_object,
-    _marker: PhantomData<T>,
+/// A reference to a GodotObject with a rust NativeClass attached.
+pub struct Instance<T: NativeClass> {
+    this: T::Base,
+    script: *mut RefCell<T>,
 }
 
-impl<T: NativeClass> NativeRef<T> {
-    /// Try to cast into a godot object reference.
-    pub fn cast<O>(&self) -> Option<O>
+impl<T: NativeClass> Instance<T> {
+    /// Creates a `T::Base` with the script `T` attached. Both `T::Base` and `T` must have zero
+    /// argument constructors.
+    /// 
+    /// Must be called after the library is initialized.
+    pub fn new() -> Self
     where
-        O: GodotObject,
+        T::Base: Instanciable,
     {
-        object::godot_cast::<O>(self.this)
-    }
-
-    /// Creates a new reference to the same object.
-    pub fn new_ref(&self) -> Self {
         unsafe {
-            object::add_ref(self.this);
+            let gd_api = get_api();
+            
+            // The API functions take NUL-terminated C strings. &CStr is not used for its runtime cost.
+            let class_name = b"NativeScript\0".as_ptr() as *const libc::c_char;
+            let ctor = (gd_api.godot_get_class_constructor)(class_name).unwrap();
+            let set_class_name = (gd_api.godot_method_bind_get_method)(class_name, b"set_class_name\0".as_ptr() as *const libc::c_char);
+            let set_library = (gd_api.godot_method_bind_get_method)(class_name, b"set_library\0".as_ptr() as *const libc::c_char);
+            let object_set_script = crate::ObjectMethodTable::get(gd_api).set_script;
 
-            Self {
-                this: self.this,
-                _marker: PhantomData,
+            let native_script = ctor();
+            object::init_ref_count(native_script);
+
+
+            let script_class_name = GodotString::from(T::class_name());
+            let mut args: [*const libc::c_void; 1] = [script_class_name.sys() as *const _];
+            (gd_api.godot_method_bind_ptrcall)(set_class_name, native_script, args.as_mut_ptr(), std::ptr::null_mut());
+
+            let mut args: [*const libc::c_void; 1] = [crate::get_gdnative_library_sys()];
+            (gd_api.godot_method_bind_ptrcall)(set_library, native_script, args.as_mut_ptr(), std::ptr::null_mut());
+
+            let this = T::Base::construct();
+
+            assert_ne!(std::ptr::null_mut(), this.to_sys(), "base object should not be null");
+
+            let mut args: [*const libc::c_void; 1] = [native_script as *const _];
+            (gd_api.godot_method_bind_ptrcall)(object_set_script, this.to_sys(), args.as_mut_ptr(), std::ptr::null_mut());
+
+            let script = (gd_api.godot_nativescript_get_userdata)(this.to_sys()) as *mut RefCell<T>;
+
+            assert_ne!(std::ptr::null_mut(), script, "script instance should not be null");
+
+            object::unref(native_script);
+
+            Instance {
+                this,
+                script,
             }
         }
     }
 
-    fn get_impl(&self) -> &RefCell<T> {
-        unsafe {
-            let api = get_api();
-            let ud = (api.godot_nativescript_get_userdata)(self.this);
-            &*(ud as *const _ as *const RefCell<T>)
-        }
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn sys(&self) -> *mut sys::godot_object {
+    pub fn into_base(self) -> T::Base {
         self.this
     }
 
-    #[doc(hidden)]
-    pub unsafe fn from_sys(ptr: *mut sys::godot_object) -> Self {
-        object::add_ref(ptr);
-
-        NativeRef {
-            this: ptr,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<T: NativeClass> Deref for NativeRef<T> {
-    type Target = RefCell<T>;
-    fn deref(&self) -> &Self::Target {
-        self.get_impl()
-    }
-}
-
-impl<T: NativeClass> Drop for NativeRef<T> {
-    fn drop(&mut self) {
+    pub fn script(&self) -> &RefCell<T> {
         unsafe {
-            if object::unref(self.this) {
-                (get_api().godot_object_destroy)(self.this);
-            }
+            &*self.script
         }
+    }
+
+    /// Calls a function with a NativeClass instance and its owner, and returns its return
+    /// value. Can be used on reference counted types for multiple times.
+    pub fn apply<F, U>(&self, op: F) -> U
+    where
+        T::Base: Clone,
+        F: FnOnce(&mut T, T::Base) -> U,
+    {
+        let mut script = self.script().borrow_mut();
+        op(&mut *script, self.this.clone())
+    }
+
+    /// Calls a function with a NativeClass instance and its owner, and returns its return
+    /// value. Can be used for multiple times via aliasing. For reference-counted types
+    /// behaves like the safe `apply`, which should be preferred.
+    pub unsafe fn apply_aliased<F, U>(&self, op: F) -> U
+    where
+        F: FnOnce(&mut T, T::Base) -> U,
+    {
+        let mut script = self.script().borrow_mut();
+        op(&mut *script, T::Base::from_sys(self.this.to_sys()))
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_sys_unchecked(ptr: *mut sys::godot_object) -> Self {
+        let api = get_api();
+        let user_data = (api.godot_nativescript_get_userdata)(ptr);
+        Self::from_raw(ptr, user_data)
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_raw(ptr: *mut sys::godot_object, user_data: *mut libc::c_void) -> Self {
+        let this = T::Base::from_sys(ptr);
+        let script = user_data as *const _ as *mut RefCell<T>;
+        Instance { this, script }
+    }
+}
+
+impl<T> ToVariant for Instance<T>
+where
+    T: NativeClass,
+    T::Base: ToVariant,
+{
+    fn to_variant(&self) -> Variant {
+        self.this.to_variant()
     }
 }
 
@@ -308,6 +355,26 @@ godot_class! {
 
         export fn _ready(&mut self, _owner: super::Object) {
             godot_print!("hello, world.");
+        }
+    }
+}
+
+#[cfg(test)]
+godot_class! {
+    class TestReturnInstanceClass: super::Object {
+
+        fields {
+        }
+
+        setup(_builder) {}
+
+        constructor(_owner: super::Object) {
+            TestReturnInstanceClass {
+            }
+        }
+
+        export fn answer(&mut self, _owner: super::Object) -> Instance<TestClass> {
+            Instance::new()
         }
     }
 }

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -30,6 +30,7 @@ pub extern crate gdnative_sys as sys;
 pub extern crate libc;
 #[macro_use]
 extern crate bitflags;
+extern crate parking_lot;
 
 pub mod geom;
 
@@ -52,6 +53,7 @@ pub mod object;
 mod rid;
 mod string;
 mod string_array;
+pub mod user_data;
 mod variant;
 mod variant_array;
 mod vector2;
@@ -74,6 +76,9 @@ pub use crate::node_path::*;
 pub use crate::object::GodotObject;
 pub use crate::object::Instanciable;
 pub use crate::rid::*;
+pub use crate::user_data::UserData;
+pub use crate::user_data::Map;
+pub use crate::user_data::MapMut;
 pub use crate::string::*;
 pub use crate::string_array::*;
 pub use crate::variant::*;

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -72,6 +72,7 @@ pub use crate::int32_array::*;
 pub use crate::internal::*;
 pub use crate::node_path::*;
 pub use crate::object::GodotObject;
+pub use crate::object::Instanciable;
 pub use crate::rid::*;
 pub use crate::string::*;
 pub use crate::string_array::*;
@@ -86,10 +87,17 @@ use std::mem;
 
 #[doc(hidden)]
 pub static mut GODOT_API: Option<GodotApi> = None;
+#[doc(hidden)]
+pub static mut GDNATIVE_LIBRARY_SYS: Option<*mut sys::godot_object> = None;
 #[inline]
 #[doc(hidden)]
 pub fn get_api() -> &'static GodotApi {
     unsafe { GODOT_API.as_ref().expect("API not bound") }
+}
+#[inline]
+#[doc(hidden)]
+pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
+    unsafe { GDNATIVE_LIBRARY_SYS.expect("GDNativeLibrary not bound") }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -324,14 +324,11 @@ macro_rules! godot_wrap_constructor {
             this: *mut $crate::sys::godot_object,
             _method_data: *mut $crate::libc::c_void,
         ) -> *mut $crate::libc::c_void {
-            use std::boxed::Box;
-            use std::cell::RefCell;
-
             // let val = $c($crate::NativeInstanceHeader{ this: this });
             let val = $c();
 
-            let wrapper = Box::new(RefCell::new(val));
-            Box::into_raw(wrapper) as *mut _
+            let wrapper = <$_name as $crate::NativeClass>::UserData::new(val);
+            wrapper.into_user_data() as *mut $crate::libc::c_void
         }
 
         constructor
@@ -349,10 +346,7 @@ macro_rules! godot_wrap_destructor {
             _method_data: *mut $crate::libc::c_void,
             user_data: *mut $crate::libc::c_void,
         ) -> () {
-            use std::boxed::Box;
-            use std::cell::RefCell;
-
-            let wrapper: Box<RefCell<$name>> = unsafe { Box::from_raw(user_data as *mut _) };
+            let wrapper = <$_name as $crate::NativeClass>::UserData::consume_user_data_unchecked(user_data);
             drop(wrapper)
         }
 
@@ -371,15 +365,14 @@ macro_rules! godot_wrap_method_parameter_count {
     }
 }
 
-/// Convenience macro to wrap an object's method into a function pointer
-/// that can be passed to the engine when registering a class.
+#[doc(hidden)]
 #[macro_export]
-macro_rules! godot_wrap_method {
-    // "proper" definition
+macro_rules! godot_wrap_method_inner {
     (
         $type_name:ty,
+        $map_method:ident,
         fn $method_name:ident(
-            &mut $self:ident,
+            $self:ident,
             $owner:ident : $owner_ty:ty
             $(,$pname:ident : $pty:ty)*
         ) -> $retty:ty
@@ -421,7 +414,7 @@ macro_rules! godot_wrap_method {
                 )*
 
                 let rust_ret = match panic::catch_unwind(AssertUnwindSafe(move || {
-                    let ret = __instance.apply_aliased(|__rust_val, $owner| __rust_val.$method_name($owner, $($pname,)*));
+                    let ret = __instance.$map_method(|__rust_val, $owner| __rust_val.$method_name($owner, $($pname,)*));
                     std::mem::drop(__instance);
                     ret
                 })) {
@@ -431,35 +424,67 @@ macro_rules! godot_wrap_method {
                     }
                 };
 
-                <$retty as $crate::ToVariant>::to_variant(&rust_ret).forget()
+                match rust_ret {
+                    Ok(val) => <$retty as $crate::ToVariant>::to_variant(&val).forget(),
+                    Err(err) => {
+                        godot_error!("gdnative-core: method call failed with error: {:?}", err);
+                        $crate::Variant::new().to_sys()
+                    } 
+                }
             }
 
             method
         }
     };
-    // non mut self
+}
+
+/// Convenience macro to wrap an object's method into a function pointer
+/// that can be passed to the engine when registering a class.
+#[macro_export]
+macro_rules! godot_wrap_method {
+    // mutable
     (
         $type_name:ty,
         fn $method_name:ident(
-            &self,
+            &mut $self:ident,
             $owner:ident : $owner_ty:ty
             $(,$pname:ident : $pty:ty)*
         ) -> $retty:ty
     ) => {
-        godot_wrap_method!(
+        godot_wrap_method_inner!(
             $type_name,
+            map_mut_aliased,
             fn $method_name(
-                &mut self,
-                $owner : $owner_ty
+                $self,
+                $owner: $owner_ty
                 $(,$pname : $pty)*
             ) -> $retty
         )
     };
-    // non mut self without return type
+    // immutable
     (
         $type_name:ty,
         fn $method_name:ident(
-            &self,
+            & $self:ident,
+            $owner:ident : $owner_ty:ty
+            $(,$pname:ident : $pty:ty)*
+        ) -> $retty:ty
+    ) => {
+        godot_wrap_method_inner!(
+            $type_name,
+            map_aliased,
+            fn $method_name(
+                $self,
+                $owner: $owner_ty
+                $(,$pname : $pty)*
+            ) -> $retty
+        )
+    };
+    // mutable without return type
+    (
+        $type_name:ty,
+        fn $method_name:ident(
+            &mut $self:ident,
             $owner:ident : $owner_ty:ty
             $(,$pname:ident : $pty:ty)*
         )
@@ -467,17 +492,17 @@ macro_rules! godot_wrap_method {
         godot_wrap_method!(
             $type_name,
             fn $method_name(
-                &mut self,
-                $owner : $owner_ty
+                &mut $self,
+                $owner: $owner_ty
                 $(,$pname : $pty)*
             ) -> ()
         )
     };
-    // without return type
+    // immutable without return type
     (
         $type_name:ty,
         fn $method_name:ident(
-            &mut self,
+            & $self:ident,
             $owner:ident : $owner_ty:ty
             $(,$pname:ident : $pty:ty)*
         )
@@ -485,8 +510,8 @@ macro_rules! godot_wrap_method {
         godot_wrap_method!(
             $type_name,
             fn $method_name(
-                &mut self,
-                $owner : $owner_ty
+                & $self,
+                $owner: $owner_ty
                 $(,$pname : $pty)*
             ) -> ()
         )

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -12,6 +12,11 @@ pub unsafe trait GodotObject {
     unsafe fn from_sys(obj: *mut sys::godot_object) -> Self;
 }
 
+/// GodotObjects that have a zero argument constructor.
+pub trait Instanciable: GodotObject {
+    fn construct() -> Self;
+}
+
 // This function assumes the godot_object is reference counted.
 pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;

--- a/gdnative-core/src/user_data.rs
+++ b/gdnative-core/src/user_data.rs
@@ -1,0 +1,390 @@
+//! Customizable user-data wrappers.
+//! 
+//! ## `NativeClass` and user-data
+//! 
+//! In Godot Engine, scripted behavior is attached to base objects through "script instances":
+//! objects that store script state, and allow dynamic dispatch of overridden methods. GDNative
+//! exposes this to native languages as a `void *` pointer, known as "user-data", that may point
+//! to anything defined by the native library in question.
+//! 
+//! Godot is written in C++, and unlike Rust, it doesn't have the same strict reference aliasing
+//! constraints. This user-data pointer can be aliased mutably, and called freely from different
+//! threads by the engine or other scripts. Thus, to maintain safety, wrapper types are be used
+//! to make sure that the Rust rules for references are always held for the `self` argument, and
+//! no UB can occur because we freed `owner` or put another script on it.
+//! 
+//! ## Which wrapper to use?
+//! 
+//! ### Use a `MutexData<T>` when:
+//! 
+//! - You don't want to handle locks explicitly.
+//! - Your `NativeClass` type is only `Send`, but not `Sync`.
+//! 
+//! ### Use a `RwLockData<T>` when:
+//! 
+//! - You don't want to handle locks explicitly.
+//! - Some of your exported methods take `&self`, and you don't need them to be exclusive.
+//! - Your `NativeClass` type is `Send + Sync`.
+//! 
+//! ### Use a `ArcData<T>` when:
+//! 
+//! - You want safety for your methods, but can't tolerate lock overhead on each method call.
+//! - You want fine grained lock control for parallelism.
+//! - All your exported methods take `&self`.
+//! - Your `NativeClass` type is `Send + Sync`.
+
+use std::mem;
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+use std::marker::PhantomData;
+use parking_lot::{Mutex, RwLock};
+
+use crate::NativeClass;
+
+/// Trait for customizable user-data wrappers.
+/// 
+/// See module-level documentation for detailed explanation on user-data.
+pub unsafe trait UserData: Sized + Clone {
+    type Target: NativeClass;
+
+    /// Creates a new owned wrapper from a `NativeClass` instance.
+    fn new(val: Self::Target) -> Self;
+
+    /// Takes a native instance and returns an opaque pointer that can be used to recover it.
+    /// 
+    /// This gives "ownership" to the engine.
+    unsafe fn into_user_data(self) -> *const libc::c_void;
+
+    /// Takes an opaque pointer produced by `into_user_data` and "consumes" it to produce the
+    /// original instance, keeping the reference count.
+    /// 
+    /// This should be used when "ownership" is taken from the engine, i.e. destructors.
+    /// Use elsewhere can lead to premature drops of the instance contained inside.
+    unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self;
+
+    /// Takes an opaque pointer produced by `into_user_data` and "clones" it to produce the
+    /// original instance, increasing the reference count.
+    /// 
+    /// This should be used when user data is "borrowed" from the engine.
+    unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self;
+}
+
+/// Trait for wrappers that can be mapped immutably.
+pub trait Map: UserData {
+    type Err: Debug;
+
+    /// Maps a `&T` to `U`. Called for methods that take `&self`.
+    fn map<F, U>(&self, op: F) -> Result<U, Self::Err>
+    where
+        F: FnOnce(&Self::Target) -> U;
+}
+
+/// Trait for wrappers that can be mapped mutably.
+pub trait MapMut: UserData {
+    type Err: Debug;
+
+    /// Maps a `&mut T` to `U`. Called for methods that take `&mut self`.
+    fn map_mut<F, U>(&self, op: F) -> Result<U, Self::Err>
+    where
+        F: FnOnce(&mut Self::Target) -> U;
+}
+
+/// The default user data wrapper used by derive macro, when no `user_data` attribute is present.
+/// This may change in the future.
+pub type DefaultUserData<T> = MutexData<T, DefaultLockPolicy>;
+
+/// Error type indicating that an operation can't fail.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum Infallible { }
+
+/// Policies to deal with potential deadlocks
+/// 
+/// As Godot allows mutable pointer aliasing, doing certain things in exported method bodies may
+/// lead to the engine calling another method on `owner`, leading to another locking attempt
+/// within the same thread:
+/// 
+/// - Variant calls on anything may dispatch to a script method.
+/// - Anything that could emit signals, that are connected to in a non-deferred manner.
+/// 
+/// As there is no universal way to deal with such situations, behavior of locking wrappers can
+/// be customized using this enum.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum DeadlockPolicy {
+    /// Block on all locks. Deadlocks are possible.
+    Allow,
+
+    /// Never block on any locks. Methods will return Nil immediately if the lock isn't
+    /// available. Deadlocks are prevented.
+    Pessimistic,
+
+    /// Block on locks for at most `Duration`. Methods return Nil on timeout. Deadlocks are
+    /// prevented.
+    Timeout(Duration),
+}
+
+/// Trait defining associated constants for locking wrapper options
+/// 
+/// This is required because constant generics ([RFC 2000][rfc-2000]) isn't available in stable
+/// rust yet.
+/// 
+/// See also `DeadlockPolicy`.
+/// 
+/// [rfc-2000]: https://github.com/rust-lang/rfcs/blob/master/text/2000-const-generics.md
+pub trait LockOptions {
+    const DEADLOCK_POLICY: DeadlockPolicy;
+}
+
+/// Default lock policy that may change in future versions.
+/// 
+/// Currently, it has a deadlock policy of `Allow`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct DefaultLockPolicy;
+
+impl LockOptions for DefaultLockPolicy {
+    const DEADLOCK_POLICY: DeadlockPolicy = DeadlockPolicy::Allow;
+}
+
+/// Error indicating that a lock wasn't obtained.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct LockFailed;
+
+/// User-data wrapper encapsulating a `Arc<Mutex<T>>`.
+/// 
+/// The underlying `Mutex` may change in the future. The current implementation is
+/// `parking_lot`.
+#[derive(Debug)]
+pub struct MutexData<T, OPT=DefaultLockPolicy> {
+    lock: Arc<Mutex<T>>,
+    _marker: PhantomData<*const OPT>,
+}
+
+unsafe impl<T, OPT> UserData for MutexData<T, OPT>
+where
+    T: NativeClass + Send,
+    OPT: LockOptions,
+{
+    type Target = T;
+
+    fn new(val: Self::Target) -> Self {
+        MutexData {
+            lock: Arc::new(Mutex::new(val)),
+            _marker: PhantomData,
+        }
+    }
+
+    unsafe fn into_user_data(self) -> *const libc::c_void {
+        Arc::into_raw(self.lock) as *const libc::c_void
+    }
+
+    unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        MutexData {
+            lock: Arc::from_raw(ptr as *const Mutex<T>),
+            _marker: PhantomData,
+        }
+    }
+
+    unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        let borrowed = Arc::from_raw(ptr as *const Mutex<T>);
+        let lock = borrowed.clone();
+        mem::forget(borrowed);
+        MutexData {
+            lock,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, OPT> Map for MutexData<T, OPT>
+where
+    T: NativeClass + Send,
+    OPT: LockOptions,
+{
+    type Err = LockFailed;
+
+    fn map<F, U>(&self, op: F) -> Result<U, LockFailed>
+    where
+        F: FnOnce(&T) -> U,
+    {
+        self.map_mut(|val| op(val))
+    }
+}
+
+
+impl<T, OPT> MapMut for MutexData<T, OPT>
+where
+    T: NativeClass + Send,
+    OPT: LockOptions,
+{
+    type Err = LockFailed;
+
+    fn map_mut<F, U>(&self, op: F) -> Result<U, LockFailed>
+    where
+        F: FnOnce(&mut T) -> U,
+    {
+        let mut guard = match OPT::DEADLOCK_POLICY {
+            DeadlockPolicy::Allow => self.lock.lock(),
+            DeadlockPolicy::Pessimistic => self.lock.try_lock().ok_or(LockFailed)?,
+            DeadlockPolicy::Timeout(dur) => self.lock.try_lock_for(dur).ok_or(LockFailed)?,
+        };
+
+        Ok(op(&mut *guard))
+    }
+}
+
+impl<T, OPT> Clone for MutexData<T, OPT> {
+    fn clone(&self) -> Self {
+        MutexData {
+            lock: self.lock.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// User-data wrapper encapsulating a `Arc<RwLock<T>>`.
+/// 
+/// The underlying `RwLock` may change in the future. The current implementation is
+/// `parking_lot`.
+#[derive(Debug)]
+pub struct RwLockData<T, OPT=DefaultLockPolicy> {
+    lock: Arc<RwLock<T>>,
+    _marker: PhantomData<*const OPT>,
+}
+
+unsafe impl<T, OPT> UserData for RwLockData<T, OPT>
+where
+    T: NativeClass + Send + Sync,
+    OPT: LockOptions,
+{
+    type Target = T;
+
+    fn new(val: Self::Target) -> Self {
+        RwLockData {
+            lock: Arc::new(RwLock::new(val)),
+            _marker: PhantomData,
+        }
+    }
+
+    unsafe fn into_user_data(self) -> *const libc::c_void {
+        Arc::into_raw(self.lock) as *const libc::c_void
+    }
+
+    unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        RwLockData {
+            lock: Arc::from_raw(ptr as *const RwLock<T>),
+            _marker: PhantomData,
+        }
+    }
+
+    unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        let borrowed = Arc::from_raw(ptr as *const RwLock<T>);
+        let lock = borrowed.clone();
+        mem::forget(borrowed);
+        RwLockData {
+            lock,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T, OPT> Map for RwLockData<T, OPT>
+where
+    T: NativeClass + Send + Sync,
+    OPT: LockOptions,
+{
+    type Err = LockFailed;
+    
+    fn map<F, U>(&self, op: F) -> Result<U, LockFailed>
+    where
+        F: FnOnce(&T) -> U,
+    {
+        let guard = match OPT::DEADLOCK_POLICY {
+            DeadlockPolicy::Allow => self.lock.read(),
+            DeadlockPolicy::Pessimistic => self.lock.try_read().ok_or(LockFailed)?,
+            DeadlockPolicy::Timeout(dur) => self.lock.try_read_for(dur).ok_or(LockFailed)?,
+        };
+
+        Ok(op(&*guard))
+    }
+}
+
+
+impl<T, OPT> MapMut for RwLockData<T, OPT>
+where
+    T: NativeClass + Send + Sync,
+    OPT: LockOptions,
+{
+    type Err = LockFailed;
+    
+    fn map_mut<F, U>(&self, op: F) -> Result<U, LockFailed>
+    where
+        F: FnOnce(&mut T) -> U,
+    {
+        let mut guard = match OPT::DEADLOCK_POLICY {
+            DeadlockPolicy::Allow => self.lock.write(),
+            DeadlockPolicy::Pessimistic => self.lock.try_write().ok_or(LockFailed)?,
+            DeadlockPolicy::Timeout(dur) => self.lock.try_write_for(dur).ok_or(LockFailed)?,
+        };
+
+        Ok(op(&mut *guard))
+    }
+}
+
+impl<T, OPT> Clone for RwLockData<T, OPT> {
+    fn clone(&self) -> Self {
+        RwLockData {
+            lock: self.lock.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// User-data wrapper encapsulating a `Arc<T>`. Does not implement `MapMut`.
+#[derive(Debug)]
+pub struct ArcData<T>(Arc<T>);
+
+unsafe impl<T> UserData for ArcData<T>
+where
+    T: NativeClass + Send + Sync,
+{
+    type Target = T;
+
+    fn new(val: Self::Target) -> Self {
+        ArcData(Arc::new(val))
+    }
+
+    unsafe fn into_user_data(self) -> *const libc::c_void {
+        Arc::into_raw(self.0) as *const libc::c_void
+    }
+
+    unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        ArcData(Arc::from_raw(ptr as *const T))
+    }
+
+    unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+        let borrowed = Arc::from_raw(ptr as *const T);
+        let arc = borrowed.clone();
+        mem::forget(borrowed);
+        ArcData(arc)
+    }
+}
+
+impl<T> Map for ArcData<T>
+where
+    T: NativeClass + Send + Sync,
+{
+    type Err = Infallible;
+
+    fn map<F, U>(&self, op: F) -> Result<U, Infallible>
+    where
+        F: FnOnce(&T) -> U,
+    {
+        Ok(op(&*self.0))
+    }
+}
+
+impl<T> Clone for ArcData<T> {
+    fn clone(&self) -> Self {
+        ArcData(self.0.clone())
+    }
+}

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -54,7 +54,7 @@ pub fn methods(meta: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
-#[proc_macro_derive(NativeClass, attributes(inherit, export))]
+#[proc_macro_derive(NativeClass, attributes(inherit, export, user_data))]
 pub fn derive_native_class(input: TokenStream) -> TokenStream {
     let data = derive_macro::parse_derive_input(input.clone());
 
@@ -62,6 +62,7 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
     let trait_impl = {
         let name = data.name;
         let base = data.base;
+        let user_data = data.user_data;
 
         // string variant needed for the `class_name` function.
         let name_str = quote!(#name).to_string();
@@ -69,6 +70,7 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
         quote!(
             impl gdnative::NativeClass for #name {
                 type Base = #base;
+                type UserData = #user_data;
 
                 fn class_name() -> &'static str {
                     #name_str

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,4 +1,6 @@
 use gdnative::*;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
 #[no_mangle]
 pub extern "C" fn run_tests(
@@ -25,6 +27,7 @@ pub extern "C" fn run_tests(
     status &= test_underscore_method_binding();
 
     status &= test_rust_class_construction();
+    status &= test_owner_free_ub();
 
     gdnative::Variant::from_bool(status).forget()
 }
@@ -66,6 +69,7 @@ struct Foo(i64);
 
 impl NativeClass for Foo {
     type Base = Reference;
+    type UserData = user_data::ArcData<Foo>;
     fn class_name() -> &'static str {
         "Foo"
     }
@@ -79,7 +83,7 @@ impl NativeClass for Foo {
 #[methods]
 impl Foo {
     #[export]
-    fn answer(&mut self, _owner: Reference) -> i64 {
+    fn answer(&self, _owner: Reference) -> i64 {
         self.0
     }
 }
@@ -89,7 +93,7 @@ fn test_rust_class_construction() -> bool {
 
     let ok = std::panic::catch_unwind(|| {
         let foo = Instance::<Foo>::new();
-        assert_eq!(42, foo.apply(|foo, owner| {
+        assert_eq!(Ok(42), foo.map(|foo, owner| {
             foo.answer(owner)
         }));
         assert_eq!(Some(42), unsafe { foo.into_base().call("answer".into(), &[]) }.try_to_i64());
@@ -102,8 +106,90 @@ fn test_rust_class_construction() -> bool {
     ok
 }
 
+struct Bar(i64, Option<Arc<AtomicUsize>>);
+
+impl NativeClass for Bar {
+    type Base = Node;
+    type UserData = user_data::RwLockData<Bar>;
+    fn class_name() -> &'static str {
+        "Bar"
+    }
+    fn init(_owner: Node) -> Bar {
+        Bar(42, None)
+    }
+    fn register_properties(_builder: &init::ClassBuilder<Self>) {
+    }
+}
+
+impl Bar {
+    fn set_drop_counter(&mut self, counter: Arc<AtomicUsize>) {
+        self.1 = Some(counter);
+    }
+}
+
+#[methods]
+impl Bar {
+    #[export]
+    fn free_is_not_ub(&mut self, owner: Node) -> bool {
+        unsafe {
+            owner.free();
+        }
+        assert_eq!(42, self.0, "self should not point to garbage");
+        true
+    }
+
+    #[export]
+    fn set_script_is_not_ub(&mut self, mut owner: Node) -> bool {
+        unsafe {
+            owner.set_script(None);
+        }
+        assert_eq!(42, self.0, "self should not point to garbage");
+        true
+    }
+}
+
+impl Drop for Bar {
+    fn drop(&mut self) {
+        let counter = self.1.take().expect("drop counter should be set");
+        counter.fetch_add(1, AtomicOrdering::AcqRel);
+        self.0 = 0;
+    }
+}
+
+fn test_owner_free_ub() -> bool {
+    println!(" -- test_owner_free_ub");
+
+    let ok = std::panic::catch_unwind(|| {
+        let drop_counter = Arc::new(AtomicUsize::new(0));
+
+        let bar = Instance::<Bar>::new();
+        unsafe {
+            bar.map_mut_aliased(|bar, _| bar.set_drop_counter(drop_counter.clone())).expect("lock should not fail");
+            let mut base = bar.into_base();
+            assert_eq!(Some(true), base.call("set_script_is_not_ub".into(), &[]).try_to_bool());
+            base.free();
+        }
+
+        let bar = Instance::<Bar>::new();
+        unsafe {
+            bar.map_mut_aliased(|bar, _| bar.set_drop_counter(drop_counter.clone())).expect("lock should not fail");
+            assert_eq!(Some(true), bar.into_base().call("free_is_not_ub".into(), &[]).try_to_bool());
+        }
+
+        // the values are eventually dropped
+        assert_eq!(2, drop_counter.load(AtomicOrdering::Acquire));
+    }).is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_owner_free_ub failed");
+    }
+
+    ok
+}
+
 fn init(handle: init::InitHandle) {
     handle.add_class::<Foo>();
+    handle.add_class::<Bar>();
 }
 
 godot_gdnative_init!();


### PR DESCRIPTION
This patch allows new objects with `NativeClass` script instances attached to be constructed and returned from Rust.

Depends on #187. Implements #154. Fixes #182.

This is a fairly large patch touching many parts of the package. Explanations for each commit are available in commit messages. Each commit should individually compile and pass tests when applied sequentially.

# Motivation

When creating an game, it's often desired to return new objects with custom Rust behaviors attached. For example:

- Custom nodes.
- `yield`-able objects like `GDScriptFunctionState`, to avoid blocking the main thread for computationally intensive operations.
- Custom data structures, to avoid expensive wholesale serialization of state into GDScript types.
- Value types with operations defined in Rust.

This is not previously possible in `godot-rust`, because as it stands, `ToVariant` can't be implemented for `NativeClass`:

1. `NativeClass` instances no longer carry the native class header, and can be constructed freely without an underlying Godot object. There is nothing to put in the resulting `Variant`.
2. Further, there is no exposed way to construct an instance *with* an underlying Godot object, at all.
3. `from_variant` is required for `ToVariant`, and there is no sensible way to implement it for `NativeClass` instances, because `user_data` is just a `Box<RefCell<T>>` with no run-time type information.

This patch changes the API in a way so (1) and (2) can be resolved, and (3) can be worked around.

# Explanation

This patch does 3 major API changes that are required for the feature to work:

1. Replaced the unused `NativeRef` type with `Instance`, that wraps around Godot objects with Rust script instances.
2. Introduced the trait `Instanciable: GodotObject` as a generic bound for type safety.
3. Made user-data wrapper customizable, and the default one safe.

## Instance API

This is a safer wrapper (compared to a plain tuple or the original `NativeRef`) around a Godot object and a Rust `NativeClass` implementation. It can be used in the following ways:

```rust
struct Foo;
impl NativeClass for Foo {
    type Base = Reference;
    // - snip -
}
#[methods]
impl Foo {
    #[export]
    fn answer(&mut self, owner: Reference) -> i64 {
        // - intricate algorithm -
        42
    }

    /// Use as return value
    #[export]
    fn fooinate(&mut self, owner: Reference) -> Instance<Foo> {
        Instance::<Foo>::new() // Creates a Reference with Foo attached
    }
}

let foo = Instance::<Foo>::new(); 
assert_eq!(42, foo.apply(|foo, owner| foo.answer(owner))); // apply clones the reference,
assert_eq!(42, foo.apply(|foo, owner| foo.answer(owner))); // so it's safe to do it again

let foo = Instance::<Foo>::new();
assert_eq!(42, unsafe { foo.apply_aliased(|foo, owner| foo.answer(owner)) }); // non-reference-counted types can be unsafely aliased if you promise it's valid and you won't free it

let base: Reference = Instance::<Foo>::new().into_base(); // upcast to base type
let variant: Variant = Instance::<Foo>::new().to_variant(); // or convert to Variant

assert_eq!(Some(42), unsafe { base.call("answer".into(), &[])) }.try_to_i64()); // it still works
```

## Instanciable

This trait is implemented by the bindings generator for all instanciable classes, and used on `Instance::new` as a generic bound on `T::Base`, making sure that only `NativeClass` instances that extend instanciable base classes can be used.

The trait has one function, `construct`, that takes no arguments and return a fresh object. It is `safe`, unlike its super trait `GodotObject`, because it's always valid to create a new instance.

## Instance::new

As an implementation detail, the function works by:

- On `gdnative_init`, save a pointer to the `GDNativeLibrary` being initialized passed through `godot_gdnative_init_options`, as a static in `gdnative-core`.
- When `Instance::new` is called, construct a `NativeScript` instance using said `GDNativeLibrary` and `NativeClass::class_name`.
- Construct a `T::Base` with `Instanciable::construct`.
- Call `Object::set_script` on the base object, with the `NativeScript` instance as argument.
- Take the user data from `T::Base` with `godot_nativescript_get_userdata`, and clone into a `NativeInstanceWrapper<T>`.
- Put both the `T::Base` and the `NativeInstanceWrapper<T>` in an `Instance` struct.

The function is implemented using direct `GodotApi` calls, to keep it all in `gdnative-core` and avoid depending on `gdnative-bindings`.

## Customizable user data storage

See conversation in #182.

# Drawbacks

- Cognitive complexity: there is a distinction between a `T: NativeClass` and an `Instance<T>`. The former is just an inert Rust value, and only the latter actually works in the engine. Users need to be taught about this.
- Ugly raw API code in `gdnative-core` depending on NativeScript classes. Not aware of a better way to do this.
- Performance: Calls to `NativeClass` functions from Godot has `Rc` overhead, but is necessary to uphold safe invariants.

# Rationale and alternatives

I consider this design better than the alternatives below because:

- Usable with only dependency on `gdnative-core`.
- Possible to replace some raw API code in macros with `Instance` calls.
- Relatively small change on API and internal workings.

## Putting Instance::new outside gdnative-core

It's possible to put the function into a new crate, e.g. `gdnative-utils`, which will depend on both `gdnative-core` and `gdnative-bindings`. However, this has multiple problems:

- One more crate to publish and keep track of.
- Less consistent API: users would expect something like `new` to be available under the type it constructs.
- In case a future, more ergonomic way to create instances is made available in Godot, the new crate would be useless.

## Re-introducing manually managed headers

- The ergonomic loss is too big, and it would require big (backwards) changes in inner workings.

## Having only GDNativeLibrary::this_library

With only `GDNativeLibrary::this_library`, construction is possible. However, without the API `Instance<T>` provides, the code to construct and use custom instances would be very clumsy, involve `unsafe`, and have little type safety. It would look something like:

```rust
// T: NativeClass
let library = GDNativeLibrary::this_library();
let mut script = NativeScript::new();
script.set_class_name(T::class_name().into());
script.set_library(Some(library));

let variant = script::_new(&[]);
let base = variant.try_to_object::<T::Base>().unwrap();

let answer_variant = unsafe { base.call("method_name".into(), &[])) };
let answer = answer_variant.try_to_i64().unwrap();
// actually use answer
```

Versus:

```rust
let instance = Instance::<T>::new();
let answer: i64 = instance.apply(|t, owner| t.method_name(owner));
// actually use answer
```

## Not doing this at all

- Won't be able to construct object from custom native class.

# Unresolved questions

## Better way to put a "one-off" function into bindings?

Currently `GDNativeLibrary::this_library` is "generated" by just writing a string into the generated file. This feels rather contrived. Is there a better way to do this (or not do this at all)?

## Creating an manually managed Instance and not passing it to the engine / freeing it leaks memory.

There is probably no way to handle them properly without some form of ownership model, as non-Reference GodotObjects drop by forgetting. Refer to #70.

## Should we implement `Send` (or even `Sync`) for Godot types?

Raw pointers are neither `Send` or `Sync` in Rust. This means that for all `NativeClass` that holds some reference to a Godot object, `Send` or `Sync` need to be manually implemented for any of the safe wrappers to be used.

Godot's C++ code contain plenty of locks, but there is no comprehensive information available about the thread safety for all the types.

I think `Sync` is certainly being too confident. Is it reasonably safe to just assume that everything is at least `Send`, since there're nothing we can do about it anyway?

# Future possibilities

## Should we implement `FromVariant` for `Instance`, and how?

Currently, it's not possible to implement `FromVariant` because the user data is just a `Box<RefCell<T>>` with no type information. This is acceptable for methods, where we trust NativeScript to call the correct functions, but unacceptable for `FromVariant`.

Further complicating the problem, is the situation that the current implementation of `godot_nativescript_get_userdata` in Godot only checks that the script is *any* NativeScript: that is, not necessarily from this library or even language. Thus, trying to read a 8-byte `TypeId`, or rather, *anything at all* from it may lead to a swift segfault.

It may be feasible to track all user data pointers and their `TypeId`s in a static HashMap, but that may incur extra cost for types that don't need to be `FromVariant`. Maybe we could introduce a separate marker trait users can explicitly opt into, and implement `FromVariant` for those types through a wrapper newtype?

This also prevents safe downcasting from `T::Base` to `Instance<T>`.

## Can we add a more ergonomic constructor to the NativeScript API itself?

The current `Instance::new` implementation is ugly, and Godot is open source. Maybe this could be changed somehow in the future.