### PR TITLE
Split ToVariant and FromVariant traits

### DIFF
--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -103,6 +103,8 @@ unsafe impl GodotObject for {name} {{
 
 impl ToVariant for {name} {{
     fn to_variant(&self) -> Variant {{ Variant::from_object(self) }}
+}}
+impl FromVariant for {name} {{
     fn from_variant(variant: &Variant) -> Option<Self> {{ variant.try_to_object::<Self>() }}
 }}"#,
         name = class.name,

--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 
@@ -110,6 +111,9 @@ impl ToVariant for ByteArray {
     fn to_variant(&self) -> Variant {
         Variant::from_byte_array(self)
     }
+}
+
+impl FromVariant for ByteArray {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_byte_array()
     }

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -2,6 +2,7 @@ use crate::get_api;
 use crate::sys;
 use crate::Color;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 
@@ -114,6 +115,9 @@ impl ToVariant for ColorArray {
     fn to_variant(&self) -> Variant {
         Variant::from_color_array(self)
     }
+}
+
+impl FromVariant for ColorArray {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_color_array()
     }

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -2,6 +2,7 @@ use crate::get_api;
 use crate::sys;
 use crate::GodotString;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 use std::fmt;
@@ -126,6 +127,9 @@ impl ToVariant for Dictionary {
     fn to_variant(&self) -> Variant {
         Variant::from_dictionary(self)
     }
+}
+
+impl FromVariant for Dictionary {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_dictionary()
     }

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 
@@ -110,6 +111,9 @@ impl ToVariant for Float32Array {
     fn to_variant(&self) -> Variant {
         Variant::from_float32_array(self)
     }
+}
+
+impl FromVariant for Float32Array {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_float32_array()
     }

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 
@@ -110,6 +111,9 @@ impl ToVariant for Int32Array {
     fn to_variant(&self) -> Variant {
         Variant::from_int32_array(self)
     }
+}
+
+impl FromVariant for Int32Array {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_int32_array()
     }

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -408,7 +408,7 @@ macro_rules! godot_wrap_method {
                 let mut offset = 0;
                 $(
                     let _variant: &$crate::Variant = ::std::mem::transmute(&mut *(*args).offset(offset));
-                    let $pname = if let Some(val) = <$pty as $crate::ToVariant>::from_variant(_variant) {
+                    let $pname = if let Some(val) = <$pty as $crate::FromVariant>::from_variant(_variant) {
                         val
                     } else {
                         godot_error!("Incorrect argument type {:?} for argument {}",

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -2,6 +2,7 @@ use crate::get_api;
 use crate::sys;
 use crate::GodotString;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use std::fmt;
 
@@ -148,6 +149,9 @@ impl ToVariant for NodePath {
     fn to_variant(&self) -> Variant {
         Variant::from_node_path(self)
     }
+}
+
+impl FromVariant for NodePath {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_node_path()
     }

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 
 use std::cmp::Ordering;
@@ -204,6 +205,9 @@ impl ToVariant for GodotString {
     fn to_variant(&self) -> Variant {
         Variant::from_godot_string(self)
     }
+}
+
+impl FromVariant for GodotString {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_godot_string()
     }

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -2,6 +2,7 @@ use crate::get_api;
 use crate::sys;
 use crate::GodotString;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 
@@ -111,6 +112,9 @@ impl ToVariant for StringArray {
     fn to_variant(&self) -> Variant {
         Variant::from_string_array(self)
     }
+}
+
+impl FromVariant for StringArray {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_string_array()
     }

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -690,9 +690,13 @@ godot_test!(
     }
 );
 
-/// Types that can be converted to and from a `Variant`.
-pub trait ToVariant: Sized {
+/// Types that can be converted to a `Variant`.
+pub trait ToVariant {
     fn to_variant(&self) -> Variant;
+}
+
+/// Types that can be converted from a `Variant`.
+pub trait FromVariant: Sized {
     fn from_variant(variant: &Variant) -> Option<Self>;
 }
 
@@ -700,7 +704,9 @@ impl ToVariant for () {
     fn to_variant(&self) -> Variant {
         Variant::new()
     }
+}
 
+impl FromVariant for () {
     fn from_variant(variant: &Variant) -> Option<Self> {
         if variant.get_type() == VariantType::Nil {
             Some(())
@@ -720,7 +726,9 @@ macro_rules! impl_to_variant_for_int {
                     Variant(ret)
                 }
             }
+        }
 
+        impl FromVariant for $ty {
             fn from_variant(variant: &Variant) -> Option<Self> {
                 unsafe {
                     let api = get_api();
@@ -752,7 +760,9 @@ macro_rules! godot_uint_impl {
                     Variant(ret)
                 }
             }
+        }
 
+        impl FromVariant for $ty {
             fn from_variant(variant: &Variant) -> Option<Self> {
                 unsafe {
                     let api = get_api();
@@ -782,7 +792,9 @@ impl ToVariant for f32 {
             Variant(ret)
         }
     }
+}
 
+impl FromVariant for f32 {
     fn from_variant(variant: &Variant) -> Option<Self> {
         unsafe {
             let api = get_api();
@@ -805,7 +817,9 @@ impl ToVariant for f64 {
             Variant(ret)
         }
     }
+}
 
+impl FromVariant for f64 {
     fn from_variant(variant: &Variant) -> Option<Self> {
         unsafe {
             let api = get_api();
@@ -824,7 +838,9 @@ impl ToVariant for String {
     fn to_variant(&self) -> Variant {
         Variant::from_str(&self)
     }
+}
 
+impl FromVariant for String {
     fn from_variant(variant: &Variant) -> Option<Self> {
         unsafe {
             let api = get_api();
@@ -850,7 +866,9 @@ impl ToVariant for bool {
     fn to_variant(&self) -> Variant {
         Variant::from_bool(*self)
     }
+}
 
+impl FromVariant for bool {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_bool()
     }
@@ -860,7 +878,9 @@ impl ToVariant for Variant {
     fn to_variant(&self) -> Variant {
         self.clone()
     }
+}
 
+impl FromVariant for Variant {
     fn from_variant(variant: &Variant) -> Option<Self> {
         Some(variant.clone())
     }

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 
 /// A reference-counted `Variant` vector. Godot's generic array data type.
@@ -176,6 +177,9 @@ impl ToVariant for VariantArray {
     fn to_variant(&self) -> Variant {
         Variant::from_array(self)
     }
+}
+
+impl FromVariant for VariantArray {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_array()
     }

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -1,4 +1,5 @@
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::Vector2;
 
@@ -6,7 +7,9 @@ impl ToVariant for Vector2 {
     fn to_variant(&self) -> Variant {
         Variant::from_vector2(self)
     }
+}
 
+impl FromVariant for Vector2 {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_vector2()
     }

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 use crate::Vector2;
@@ -114,6 +115,9 @@ impl ToVariant for Vector2Array {
     fn to_variant(&self) -> Variant {
         Variant::from_vector2_array(self)
     }
+}
+
+impl FromVariant for Vector2Array {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_vector2_array()
     }

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -1,4 +1,5 @@
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::Vector3;
 
@@ -6,7 +7,9 @@ impl ToVariant for Vector3 {
     fn to_variant(&self) -> Variant {
         Variant::from_vector3(self)
     }
+}
 
+impl FromVariant for Vector3 {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_vector3()
     }

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -1,6 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::ToVariant;
+use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 use crate::Vector3;
@@ -114,6 +115,9 @@ impl ToVariant for Vector3Array {
     fn to_variant(&self) -> Variant {
         Variant::from_vector3_array(self)
     }
+}
+
+impl FromVariant for Vector3Array {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_vector3_array()
     }


### PR DESCRIPTION
Cherry-picked this off #181 because I think it would still be useful out of that PR's context, and can be reviewed individually, for use cases like https://github.com/GodotNativeTools/godot-rust/issues/185#issuecomment-526078735, where you only really need a one-way conversion.

Related sections from the original PR comment:

## Explanation

This allows types to be separately `ToVariant` and `FromVariant`. `ToVariant` no longer require `Sized`. Bounds on export function arguments, return values, and property getter / setters are relaxed to require only one of these traits. As such, it's now possible to:

- Use a type that is only `FromVariant` as an argument. e.g. a custom "options" struct that reads from a `Dictionary`.
- Use a type that is only `ToVariant` as a return value. e.g. `Instance<T>`.
- Make `ToVariant` types into trait objects and send them through Rust channels: `Box<dyn ToVariant + Send + 'static>`.

All types that previously implement `ToVariant` are now also `FromVariant`.

## Drawbacks

- Compatibility break: all previous `ToVariant` implementations on custom types are void, although a fix is very easy.
- Compatibility break: Dependent code that use `ToVariant` as a bound and call `from_variant` need to do use `FromVariant` (or `ToVariant + FromVariant`) instead.