### PR TITLE
Fix method argument layout assumption

### DIFF
--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -498,7 +498,7 @@ macro_rules! godot_wrap_method_inner {
 
                 let mut offset = 0;
                 $(
-                    let _variant: &$crate::Variant = ::std::mem::transmute(&mut *(*args).offset(offset));
+                    let _variant: &$crate::Variant = ::std::mem::transmute(&mut **(args.offset(offset)));
                     let $pname = if let Some(val) = <$pty as $crate::FromVariant>::from_variant(_variant) {
                         val
                     } else {

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -1,14 +1,19 @@
 extends Node
 
+var gdn
+
 func _ready():
     print(" -- Rust gdnative test suite:")
-    var gdn = GDNative.new()
+    gdn = GDNative.new()
     var status = false;
 
     gdn.library = load("res://gdnative.gdnlib")
 
     if gdn.initialize():
         status = gdn.call_native("standard_varcall", "run_tests", [])
+
+        status = status && _test_argument_passing_sanity()
+
         gdn.terminate()
     else:
         print(" -- Could not load the gdnative library.")
@@ -21,3 +26,37 @@ func _ready():
 
     print(" -- exiting.")
     get_tree().quit()
+
+func _test_argument_passing_sanity():
+    print(" -- test_argument_passing_sanity")
+
+    var script = NativeScript.new()
+    script.set_library(gdn.library)
+    script.set_class_name("Foo")
+    var foo = Reference.new()
+    foo.set_script(script)
+    
+    var status = true
+
+    status = status && _assert_choose("foo", foo, "choose", "foo", true, "bar")
+    status = status && _assert_choose("night", foo, "choose", "day", false, "night")
+    status = status && _assert_choose(42, foo, "choose_variant", 42, "int", 54.0)
+    status = status && _assert_choose(9.0, foo, "choose_variant", 6, "float", 9.0)
+
+    if status:
+        assert("foo" == foo.choose("foo", true, "bar"))
+        assert("night" == foo.choose("day", false, "night"))
+        assert(42 == foo.choose_variant(42, "int", 54.0))
+        assert(9.0 == foo.choose_variant(6, "float", 9.0))
+
+    if !status:
+        printerr("   !! test_argument_passing_sanity failed")
+
+    return status
+
+func _assert_choose(expected, foo, fun, a, which, b):
+    var got_value = foo.call(fun, a, which, b)
+    if got_value == expected:
+        return true
+    printerr("   !! expected ", expected, ", got ", got_value)
+    return false

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -91,6 +91,26 @@ impl Foo {
     fn answer(&self, _owner: Reference) -> i64 {
         self.0
     }
+
+    #[export]
+    fn choose(&self, _owner: Reference, a: GodotString, which: bool, b: GodotString) -> GodotString {
+        if which {
+            a
+        }
+        else {
+            b
+        }
+    }
+
+    #[export]
+    fn choose_variant(&self, _owner: Reference, a: i32, what: Variant, b: f64) -> Variant {
+        let what = what.try_to_string().expect("should be string");
+        match what.as_str() {
+            "int" => a.to_variant(),
+            "float" => b.to_variant(),
+            _ => panic!("should be int or float, got {:?}", what),
+        }
+    }
 }
 
 fn test_rust_class_construction() -> bool {


### PR DESCRIPTION
Arguments from Godot are passed in as a pointer to an array of pointers to variants, but was mistakenly interpreted as a pointer to an pointer to an array of variants. This caused calls by method call syntax to fail due to the layout difference.

Blame the ambiguity of C type signatures and GDNative's lack of documentation...

Fixes #190