### PR TITLE
Support optional arguments

### DIFF
--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -18,7 +18,7 @@ pub fn methods(meta: TokenStream, input: TokenStream) -> TokenStream {
 
 #[proc_macro_derive(
     NativeClass,
-    attributes(inherit, export, user_data, property, register_with)
+    attributes(inherit, export, opt, user_data, property, register_with)
 )]
 pub fn derive_native_class(input: TokenStream) -> TokenStream {
     native_script::derive_native_class(input)

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -13,6 +13,7 @@ func _ready():
         status = gdn.call_native("standard_varcall", "run_tests", [])
 
         status = status && _test_argument_passing_sanity()
+        status = status && _test_optional_args()
 
         gdn.terminate()
     else:
@@ -56,6 +57,40 @@ func _test_argument_passing_sanity():
 
 func _assert_choose(expected, foo, fun, a, which, b):
     var got_value = foo.call(fun, a, which, b)
+    if got_value == expected:
+        return true
+    printerr("   !! expected ", expected, ", got ", got_value)
+    return false
+
+func _test_optional_args():
+    print(" -- _test_optional_args")
+    print("   -- expected error messages for edge cases:")
+    print("     -- Incorrect number of parameters: required 2 but got 1")
+    print("     -- Incorrect number of parameters: expected at most 5 but got 6")
+    print("   -- the test is successful when and only when these errors are shown")
+
+    var script = NativeScript.new()
+    script.set_library(gdn.library)
+    script.set_class_name("OptionalArgs")
+    var opt_args = Reference.new()
+    opt_args.set_script(script)
+
+    var status = true
+
+    status = status && _assert_opt_args(null, opt_args, [1])
+    status = status && _assert_opt_args(2, opt_args, [1, 1])
+    status = status && _assert_opt_args(6, opt_args, [1, 3, 2])
+    status = status && _assert_opt_args(13, opt_args, [5, 1, 3, 4])
+    status = status && _assert_opt_args(42, opt_args, [4, 1, 20, 4, 13])
+    status = status && _assert_opt_args(null, opt_args, [1, 2, 3, 4, 5, 6])
+
+    if !status:
+        printerr("   !! _test_optional_args failed")
+
+    return status
+
+func _assert_opt_args(expected, opt_args, args):
+    var got_value = opt_args.callv("opt_sum", args);
     if got_value == expected:
         return true
     printerr("   !! expected ", expected, ", got ", got_value)

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -176,8 +176,35 @@ fn test_rust_class_construction() -> bool {
     ok
 }
 
+#[derive(NativeClass)]
+#[inherit(Reference)]
+struct OptionalArgs;
+
+impl OptionalArgs {
+    fn _init(_owner: Reference) -> Self {
+        OptionalArgs
+    }
+}
+
+#[methods]
+impl OptionalArgs {
+    #[export]
+    fn opt_sum(
+        &self,
+        _owner: Reference,
+        a: i64,
+        b: i64,
+        #[opt] c: i64,
+        #[opt] d: i64,
+        #[opt] e: i64,
+    ) -> i64 {
+        a + b + c + d + e
+    }
+}
+
 fn init(handle: init::InitHandle) {
     handle.add_class::<Foo>();
+    handle.add_class::<OptionalArgs>();
 
     test_derive::register(&handle);
     test_free_ub::register(&handle);


### PR DESCRIPTION
As @karroffel mentioned that a new cargo version is coming soon, I think it might be a good time to move this out of draft status, so the feature might get into the release!

Implements optional arguments in both `godot_wrap_method` and the `methods` procedural macro. Closes #185.

# Explanation

This patch allows declaring optional arguments with the following syntax:

With `godot_wrap_method`:

```rust
builder.add_method("some_method", godot_wrap_method!(
    SomeType,
    fn some_method(&self, owner: Node, foo: i64, #[opt] bar: Option<String>, #[opt] baz: Variant) -> ()
));
```

With the procedural macro:

```rust
#[methods]
impl SomeType {
    #[export]
    fn some_method(&self, owner: Node, foo: i64, #[opt] bar: Option<String>, #[opt] baz: Variant) -> () {
        let bar = bar.unwrap_or_else(|| "DefaultValue".to_owned());
        // ... do things with bar ...
    }
}
```

Default values for optional arguments are obtained with `Default`. The behavior regarding `Option<T>` is consistent with its `FromVariant` implementation, so it should be easy to convert an existing function into one with optional arguments.

# Future possibilities

## VarArgs methods

With attribute argument parsing in place, it should be easy to later extend the syntax to allow VarArgs methods. Sample:

```rust
#[methods]
impl SomeType {
    /// foo is required, bar and baz are optional, and rest contains the rest of arguments if any remains
    #[export]
    fn some_method(&self, owner: Node, foo: i64, #[opt] bar: Option<String>, #[opt] baz: Variant, #[var] rest: VariantArray) -> () {
        // - snip -
    }
}
```