### PR TITLE
Implement String, Vector2, Vector3 array access, and VariantArray iterators

### DIFF
--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -17,17 +17,48 @@ impl FromVariant for Vector2 {
 
 godot_test!(
     test_vector2_variants {
-        let vector = Vector2::new(1.0, 2.0);
-        let variant = vector.to_variant();
-        let vector_from_variant = Vector2::from_variant(&variant).unwrap();
+        fn test(vector: Vector2, set_to: Vector2) {
+            let api = crate::get_api();
 
-        assert_eq!(vector, vector_from_variant);
+            let copied = vector;
+            unsafe {
+                assert_eq!(vector.x, (api.godot_vector2_get_x)(&copied as *const _ as *const sys::godot_vector2));
+                assert_eq!(vector.y, (api.godot_vector2_get_y)(&copied as *const _ as *const sys::godot_vector2));
+            }
+            assert_eq!(vector, copied);
+
+            let mut copied = vector;
+            unsafe {
+                (api.godot_vector2_set_x)(&mut copied as *mut _ as *mut sys::godot_vector2, set_to.x);
+                (api.godot_vector2_set_y)(&mut copied as *mut _ as *mut sys::godot_vector2, set_to.y);
+            }
+            assert_eq!(set_to, copied);
+
+            let variant = vector.to_variant();
+            let vector_from_variant = Vector2::from_variant(&variant).unwrap();
+            assert_eq!(vector, vector_from_variant);
+        }
+
+        test(Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0));
+        test(Vector2::new(3.0, 4.0), Vector2::new(5.0, 6.0));
     }
     );
 
 #[cfg(test)]
 mod tests {
     use super::Vector2;
+
+    #[test]
+    fn it_is_copy() {
+        fn copy<T: Copy>() {}
+        copy::<Vector2>();
+    }
+
+    #[test]
+    fn it_has_the_same_size() {
+        use std::mem::size_of;
+        assert_eq!(size_of::<sys::godot_vector2>(), size_of::<Vector2>());
+    }
 
     #[test]
     fn it_supports_equality() {

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -5,11 +5,15 @@ use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 use crate::Vector2;
+use crate::access::{MaybeUnaligned, Aligned};
 
 use std::mem::transmute;
 
 /// A reference-counted vector of `Vector2` that uses Godot's pool allocator.
 pub struct Vector2Array(pub(crate) sys::godot_pool_vector2_array);
+
+pub type Read<'a> = Aligned<ReadGuard<'a>>;
+pub type Write<'a> = Aligned<WriteGuard<'a>>;
 
 impl Vector2Array {
     /// Creates an empty array.
@@ -88,6 +92,22 @@ impl Vector2Array {
         unsafe { (get_api().godot_pool_vector2_array_size)(&self.0) }
     }
 
+    pub fn read<'a>(&'a self) -> Read<'a> {
+        unsafe {
+            MaybeUnaligned::new(ReadGuard::new(self.sys()))
+                .try_into_aligned()
+                .expect("Pool array access should be aligned. This indicates a bug in Godot")
+        }
+    }
+
+    pub fn write<'a>(&'a mut self) -> Write<'a> {
+        unsafe {
+            MaybeUnaligned::new(WriteGuard::new(self.sys() as *mut _))
+                .try_into_aligned()
+                .expect("Pool array access should be aligned. This indicates a bug in Godot")
+        }
+    }
+
     #[doc(hidden)]
     pub fn sys(&self) -> *const sys::godot_pool_vector2_array {
         &self.0
@@ -122,3 +142,62 @@ impl FromVariant for Vector2Array {
         variant.try_to_vector2_array()
     }
 }
+
+define_access_guard! {
+    pub struct ReadGuard<'a> : sys::godot_pool_vector2_array_read_access {
+        access = godot_pool_vector2_array_read(*const sys::godot_pool_vector2_array),
+        len = godot_pool_vector2_array_size,
+    }
+    Guard<Target=Vector2> => godot_pool_vector2_array_read_access_ptr -> *const sys::godot_vector2;
+    Drop => godot_pool_vector2_array_read_access_destroy;
+    Clone => godot_pool_vector2_array_read_access_copy;
+}
+
+define_access_guard! {
+    pub struct WriteGuard<'a> : sys::godot_pool_vector2_array_write_access {
+        access = godot_pool_vector2_array_write(*mut sys::godot_pool_vector2_array),
+        len = godot_pool_vector2_array_size,
+    }
+    Guard<Target=Vector2> + WritePtr => godot_pool_vector2_array_write_access_ptr -> *mut sys::godot_vector2;
+    Drop => godot_pool_vector2_array_write_access_destroy;
+}
+
+godot_test!(
+    test_vector2_array_access {
+        let mut arr = Vector2Array::new();
+        arr.push(&Vector2::new(1.0, 2.0));
+        arr.push(&Vector2::new(3.0, 4.0));
+        arr.push(&Vector2::new(5.0, 6.0));
+        
+        let original_read = {
+            let read = arr.read();
+            assert_eq!(&[
+                Vector2::new(1.0, 2.0),
+                Vector2::new(3.0, 4.0),
+                Vector2::new(5.0, 6.0),
+            ], read.as_slice());
+            read.clone()
+        };
+
+        let mut cow_arr = arr.new_ref();
+
+        {
+            let mut write = cow_arr.write();
+            assert_eq!(3, write.len());
+            for s in write.as_mut_slice() {
+                s.x += 1.0;
+            }
+        }
+
+        assert_eq!(Vector2::new(2.0, 2.0), cow_arr.get(0));
+        assert_eq!(Vector2::new(4.0, 4.0), cow_arr.get(1));
+        assert_eq!(Vector2::new(6.0, 6.0), cow_arr.get(2));
+        
+        // the write shouldn't have affected the original array
+        assert_eq!(&[
+            Vector2::new(1.0, 2.0),
+            Vector2::new(3.0, 4.0),
+            Vector2::new(5.0, 6.0),
+        ], original_read.as_slice());
+    }
+);

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -17,17 +17,50 @@ impl FromVariant for Vector3 {
 
 godot_test!(
     test_vector3_variants {
-        let vector = Vector3::new(1.0, 2.0, 3.0);
-        let variant = vector.to_variant();
-        let vector_from_variant = Vector3::from_variant(&variant).unwrap();
+        fn test(vector: Vector3, set_to: Vector3) {
+            let api = crate::get_api();
 
-        assert_eq!(vector, vector_from_variant);
+            let copied = vector;
+            unsafe {
+                assert_eq!(vector.x, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::X as u32));
+                assert_eq!(vector.y, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::Y as u32));
+                assert_eq!(vector.z, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::Z as u32));
+            }
+            assert_eq!(vector, copied);
+
+            let mut copied = vector;
+            unsafe {
+                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::X as u32, set_to.x);
+                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::Y as u32, set_to.y);
+                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::Z as u32, set_to.z);
+            }
+            assert_eq!(set_to, copied);
+
+            let variant = vector.to_variant();
+            let vector_from_variant = Vector3::from_variant(&variant).unwrap();
+            assert_eq!(vector, vector_from_variant);
+        }
+
+        test(Vector3::new(1.0, 2.0, 3.0), Vector3::new(4.0, 5.0, 6.0));
+        test(Vector3::new(4.0, 5.0, 6.0), Vector3::new(7.0, 8.0, 9.0));
     }
     );
 
 #[cfg(test)]
 mod tests {
     use super::Vector3;
+
+    #[test]
+    fn it_is_copy() {
+        fn copy<T: Copy>() {}
+        copy::<Vector3>();
+    }
+
+    #[test]
+    fn it_has_the_same_size() {
+        use std::mem::size_of;
+        assert_eq!(size_of::<sys::godot_vector3>(), size_of::<Vector3>());
+    }
 
     #[test]
     fn it_supports_equality() {

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -5,11 +5,15 @@ use crate::FromVariant;
 use crate::Variant;
 use crate::VariantArray;
 use crate::Vector3;
+use crate::access::{MaybeUnaligned, Aligned};
 
 use std::mem::transmute;
 
 /// A reference-counted vector of `Vector3` that uses Godot's pool allocator.
 pub struct Vector3Array(pub(crate) sys::godot_pool_vector3_array);
+
+pub type Read<'a> = Aligned<ReadGuard<'a>>;
+pub type Write<'a> = Aligned<WriteGuard<'a>>;
 
 impl Vector3Array {
     /// Creates an empty array.
@@ -88,6 +92,22 @@ impl Vector3Array {
         unsafe { (get_api().godot_pool_vector3_array_size)(&self.0) }
     }
 
+    pub fn read<'a>(&'a self) -> Read<'a> {
+        unsafe {
+            MaybeUnaligned::new(ReadGuard::new(self.sys()))
+                .try_into_aligned()
+                .expect("Pool array access should be aligned. This indicates a bug in Godot")
+        }
+    }
+
+    pub fn write<'a>(&'a mut self) -> Write<'a> {
+        unsafe {
+            MaybeUnaligned::new(WriteGuard::new(self.sys() as *mut _))
+                .try_into_aligned()
+                .expect("Pool array access should be aligned. This indicates a bug in Godot")
+        }
+    }
+
     #[doc(hidden)]
     pub fn sys(&self) -> *const sys::godot_pool_vector3_array {
         &self.0
@@ -122,3 +142,63 @@ impl FromVariant for Vector3Array {
         variant.try_to_vector3_array()
     }
 }
+
+define_access_guard! {
+    pub struct ReadGuard<'a> : sys::godot_pool_vector3_array_read_access {
+        access = godot_pool_vector3_array_read(*const sys::godot_pool_vector3_array),
+        len = godot_pool_vector3_array_size,
+    }
+    Guard<Target=Vector3> => godot_pool_vector3_array_read_access_ptr -> *const sys::godot_vector3;
+    Drop => godot_pool_vector3_array_read_access_destroy;
+    Clone => godot_pool_vector3_array_read_access_copy;
+}
+
+define_access_guard! {
+    pub struct WriteGuard<'a> : sys::godot_pool_vector3_array_write_access {
+        access = godot_pool_vector3_array_write(*mut sys::godot_pool_vector3_array),
+        len = godot_pool_vector3_array_size,
+    }
+    Guard<Target=Vector3> + WritePtr => godot_pool_vector3_array_write_access_ptr -> *mut sys::godot_vector3;
+    Drop => godot_pool_vector3_array_write_access_destroy;
+}
+
+godot_test!(
+    test_vector3_array_access {
+        let mut arr = Vector3Array::new();
+        arr.push(&Vector3::new(1.0, 2.0, 3.0));
+        arr.push(&Vector3::new(3.0, 4.0, 5.0));
+        arr.push(&Vector3::new(5.0, 6.0, 7.0));
+        
+        let original_read = {
+            let read = arr.read();
+            assert_eq!(&[
+                Vector3::new(1.0, 2.0, 3.0),
+                Vector3::new(3.0, 4.0, 5.0),
+                Vector3::new(5.0, 6.0, 7.0),
+            ], read.as_slice());
+            read.clone()
+        };
+
+        let mut cow_arr = arr.new_ref();
+
+        {
+            let mut write = cow_arr.write();
+            assert_eq!(3, write.len());
+            for s in write.as_mut_slice() {
+                s.x += 2.0;
+                s.y += 1.0;
+            }
+        }
+
+        assert_eq!(Vector3::new(3.0, 3.0, 3.0), cow_arr.get(0));
+        assert_eq!(Vector3::new(5.0, 5.0, 5.0), cow_arr.get(1));
+        assert_eq!(Vector3::new(7.0, 7.0, 7.0), cow_arr.get(2));
+        
+        // the write shouldn't have affected the original array
+        assert_eq!(&[
+            Vector3::new(1.0, 2.0, 3.0),
+            Vector3::new(3.0, 4.0, 5.0),
+            Vector3::new(5.0, 6.0, 7.0),
+        ], original_read.as_slice());
+    }
+);

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -32,6 +32,9 @@ pub extern "C" fn run_tests(
     status &= gdnative::test_int32_array_access();
     status &= gdnative::test_float32_array_access();
     status &= gdnative::test_color_array_access();
+    status &= gdnative::test_string_array_access();
+    status &= gdnative::test_vector2_array_access();
+    status &= gdnative::test_vector3_array_access();
 
     status &= test_constructor();
     status &= test_underscore_method_binding();


### PR DESCRIPTION
Closes #7. Closes #184. Closes #32 (as you can do `arr.read().iter()` or `arr.write().iter_mut()` on the pool arrays). 

The mutable iterator for `VariantArray` is going to be very expensive due to CoW, since we don't get access to `ptrw`. Maybe it's better to leave it out?