### PR TITLE
Add accessors to user-data wrapper on Instance

### DIFF
--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -132,6 +132,22 @@ impl<T: NativeClass> Instance<T> {
         self.owner
     }
 
+    pub fn into_script(self) -> T::UserData {
+        self.script
+    }
+
+    pub fn decouple(self) -> (T::Base, T::UserData) {
+        (self.owner, self.script)
+    }
+
+    pub fn base(&self) -> &T::Base {
+        &self.owner
+    }
+
+    pub fn script(&self) -> &T::UserData {
+        &self.script
+    }
+
     /// Calls a function with a NativeClass instance and its owner, and returns its return
     /// value. Can be used on reference counted types for multiple times.
     pub fn map<F, U>(&self, op: F) -> Result<U, <T::UserData as Map>::Err>


### PR DESCRIPTION
Sometimes only the script part needs to be accessed on an Instance with a non-refcounted base class. This removes the need to use `unsafe` and allows one to `map` on the script instance directly (without access to `owner`). Similarly, one may want to only use the base object. This adds more accessors to `Instance` to facilitate such use cases.