### PR TITLE
Remove *const from lock policy PhantomData.

### DIFF
--- a/gdnative-core/src/user_data.rs
+++ b/gdnative-core/src/user_data.rs
@@ -156,7 +156,7 @@ pub struct LockFailed;
 #[derive(Debug)]
 pub struct MutexData<T, OPT=DefaultLockPolicy> {
     lock: Arc<Mutex<T>>,
-    _marker: PhantomData<*const OPT>,
+    _marker: PhantomData<OPT>,
 }
 
 unsafe impl<T, OPT> UserData for MutexData<T, OPT>
@@ -248,7 +248,7 @@ impl<T, OPT> Clone for MutexData<T, OPT> {
 #[derive(Debug)]
 pub struct RwLockData<T, OPT=DefaultLockPolicy> {
     lock: Arc<RwLock<T>>,
-    _marker: PhantomData<*const OPT>,
+    _marker: PhantomData<OPT>,
 }
 
 unsafe impl<T, OPT> UserData for RwLockData<T, OPT>


### PR DESCRIPTION
The `*const` part in lock policy `PhantomData`s made locking user-data wrappers spuriously non-Send/Sync, preventing them from being passed to other threads.

Changing the `PhantomData` declaration should fix the problem.