### PR TITLE
Cast enums to/from bindgen type alias instead of u32

### DIFF
--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -174,5 +174,5 @@ pub fn result_from_sys(err: sys::godot_error) -> GodotResult {
         return Ok(());
     }
 
-    Err(unsafe { mem::transmute(err) })
+    Err(unsafe { mem::transmute(err as u32) })
 }

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -149,7 +149,7 @@ pub enum VariantType {
 impl VariantType {
     #[doc(hidden)]
     pub fn from_sys(v: sys::godot_variant_type) -> VariantType {
-        unsafe { transmute(v) }
+        unsafe { transmute(v as u32) }
     }
 }
 

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -22,17 +22,38 @@ godot_test!(
 
             let copied = vector;
             unsafe {
-                assert_eq!(vector.x, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::X as u32));
-                assert_eq!(vector.y, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::Y as u32));
-                assert_eq!(vector.z, (api.godot_vector3_get_axis)(&copied as *const _ as *const sys::godot_vector3, crate::Vector3Axis::Z as u32));
+                assert_eq!(vector.x, (api.godot_vector3_get_axis)(
+                    &copied as *const _ as *const sys::godot_vector3,
+                    crate::Vector3Axis::X as u32 as sys::godot_vector3_axis
+                ));
+                assert_eq!(vector.y, (api.godot_vector3_get_axis)(
+                    &copied as *const _ as *const sys::godot_vector3,
+                    crate::Vector3Axis::Y as u32 as sys::godot_vector3_axis
+                ));
+                assert_eq!(vector.z, (api.godot_vector3_get_axis)(
+                    &copied as *const _ as *const sys::godot_vector3,
+                    crate::Vector3Axis::Z as u32 as sys::godot_vector3_axis
+                ));
             }
             assert_eq!(vector, copied);
 
             let mut copied = vector;
             unsafe {
-                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::X as u32, set_to.x);
-                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::Y as u32, set_to.y);
-                (api.godot_vector3_set_axis)(&mut copied as *mut _ as *mut sys::godot_vector3, crate::Vector3Axis::Z as u32, set_to.z);
+                (api.godot_vector3_set_axis)(
+                    &mut copied as *mut _ as *mut sys::godot_vector3,
+                    crate::Vector3Axis::X as u32 as sys::godot_vector3_axis,
+                    set_to.x
+                );
+                (api.godot_vector3_set_axis)(
+                    &mut copied as *mut _ as *mut sys::godot_vector3,
+                    crate::Vector3Axis::Y as u32 as sys::godot_vector3_axis,
+                    set_to.y
+                );
+                (api.godot_vector3_set_axis)(
+                    &mut copied as *mut _ as *mut sys::godot_vector3,
+                    crate::Vector3Axis::Z as u32 as sys::godot_vector3_axis,
+                    set_to.z
+                );
             }
             assert_eq!(set_to, copied);
 


### PR DESCRIPTION
This may fix type errors if the enum representations are platform-dependent.