### PR TITLE
Add Windows target files for example projects

### DIFF
--- a/examples/hello_world/hello_world_library.gdnlib
+++ b/examples/hello_world/hello_world_library.gdnlib
@@ -1,7 +1,8 @@
 [entry]
 
-X11.64="../../target/debug/libhello_world.so"
-OSX.64="../../target/debug/libhello_world.dylib"
+X11.64="res://../../target/debug/libhello_world.so"
+OSX.64="res://../../target/debug/libhello_world.dylib"
+Windows.64="res://../../target/debug/hello_world.dll"
 
 [dependencies]
 

--- a/examples/scene_create/scene_create_library.gdnlib
+++ b/examples/scene_create/scene_create_library.gdnlib
@@ -7,8 +7,8 @@ reloadable=true
 
 [entry]
 
-OSX.64="../../target/debug/libscene_create.dylib"
-X11.64="../../target/debug/libscene_create.so"
+OSX.64="res://../../target/debug/libscene_create.dylib"
+X11.64="res://../../target/debug/libscene_create.so"
 Windows.64="res://../../target/debug/scene_create.dll"
 
 [dependencies]

--- a/examples/spinning_cube/spinning_cube_library.gdnlib
+++ b/examples/spinning_cube/spinning_cube_library.gdnlib
@@ -1,7 +1,9 @@
 [entry]
 
-X11.64="../../target/debug/libspinning_cube.so"
-OSX.64="../../target/debug/libspinning_cube.dylib"
+X11.64="res://../../target/debug/libspinning_cube.so"
+OSX.64="res://../../target/debug/libspinning_cube.dylib"
+Windows.64="res://../../target/debug/spinning_cube.dll"
+
 
 [dependencies]
 


### PR DESCRIPTION
**While working on a getting started tutorial** 
https://medium.com/@recallsingularity/gorgeous-godot-games-in-rust-1867c56045e6

**also mentioned here**
https://www.reddit.com/r/godot/comments/d75yj9/rust_scripting_in_godot_a_hello_world_tutorial/

I realized that the example targets for windows are missing. I thought that we need to put those in for a nice seamless getting started experience.

Thanks for your continued work on the repo guys. I have some other PRs I need to merge back in soon...