### PR TITLE
First Helper functions for Basis and Transform

### DIFF
--- a/gdnative-core/src/geom/basis.rs
+++ b/gdnative-core/src/geom/basis.rs
@@ -1,4 +1,5 @@
 use crate::Vector3;
+use euclid::{Vector3D, Transform3D};
 
 /// A 3x3 matrix.
 #[repr(C)]
@@ -7,4 +8,72 @@ pub struct Basis {
     pub elements: [Vector3; 3],
 }
 
-// TODO methods!
+// TODO more methods!
+// Feel free to get inspiration from godot-src\core\math\basis.cpp
+impl Basis {
+    pub fn identity() -> Basis {
+        Basis { 
+            elements: [
+                Vector3::new(1.0, 0.0, 0.0),
+                Vector3::new(0.0, 1.0, 0.0),
+                Vector3::new(0.0, 0.0, 1.0),
+            ]
+        }
+    }
+
+    pub fn from_diagonal(p_diag: Vector3) -> Basis {
+        Basis {
+            elements: [
+                Vector3::new(p_diag.x, 0.0, 0.0),
+                Vector3::new(0.0, p_diag.y, 0.0),
+                Vector3::new(0.0, 0.0, p_diag.z),
+            ]
+        }
+    }
+
+    // Note: It's ok to use euclid::UnknownUnit as the type for both Src and Dst
+    pub fn from_transform<Src, Dst>(transform: &Transform3D<f32, Src, Dst>) -> Basis {
+        // Note - this encodes just the rotation and scaling
+        Basis {
+            elements: [
+                transform.transform_vector3d(Vector3D::<_, Src>::new(1.0, 0.0, 0.0)).to_untyped(),
+                transform.transform_vector3d(Vector3D::<_, Src>::new(0.0, 1.0, 0.0)).to_untyped(),
+                transform.transform_vector3d(Vector3D::<_, Src>::new(0.0, 0.0, 1.0)).to_untyped(),
+            ]
+        }
+    }
+//
+//    /// set_euler_yxz expects a vector containing the Euler angles in the format
+//    /// (ax,ay,az), where ax is the angle of rotation around x axis,
+//    /// and similar for other axes.
+//    /// The current implementation uses YXZ convention (Z is the first rotation).
+//    pub fn from_euler_yxz(p_euler: Vector3) -> Basis {
+//
+//        let c = Math::cos(p_euler.x);
+//        let s = Math::sin(p_euler.x);
+//        let xmat = Basis::element_new(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+//
+//        let c = Math::cos(p_euler.y);
+//        let s = Math::sin(p_euler.y);
+//        let ymat = Basis::element_new(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+//
+//        let c = Math::cos(p_euler.z);
+//        let s = Math::sin(p_euler.z);
+//        let zmat = Basis::element_new(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+//
+//        // optimizer will optimize away all this anyway
+//        ymat * xmat * zmat;
+//    }
+//
+//    // transposed dot products
+//    fn tdotx(&self, v: Vector3) -> f32 {
+//        self.elements[0].x * v[0] + self.elements[1].x * v[1] + self.elements[2].x * v[2]
+//    }
+//    fn tdoty(&self, v: Vector3) -> f32 {
+//        self.elements[0].y * v[0] + self.elements[1].y * v[1] + self.elements[2].y * v[2]
+//    }
+//    fn tdotz(&self, v: Vector3) -> f32 {
+//        self.elements[0].z * v[0] + self.elements[1].z * v[1] + self.elements[2].z * v[2]
+//    }
+
+}

--- a/gdnative-core/src/geom/transform.rs
+++ b/gdnative-core/src/geom/transform.rs
@@ -1,4 +1,5 @@
 use crate::{Basis, Vector3};
+use euclid::{Transform3D, Point3D};
 
 /// 3D Transformation (3x4 matrix) Using basis + origin representation.
 #[repr(C)]
@@ -13,3 +14,19 @@ pub struct Transform {
 }
 
 // TODO: methods!
+impl Transform {
+    pub fn translate(origin: Vector3) -> Transform {
+        Transform {
+            basis: Basis::identity(),
+            origin
+        }
+    }
+
+    pub fn from_transform<Src, Dst>(transform: &Transform3D<f32, Src, Dst>) -> Transform {
+        Transform {
+            basis: Basis::from_transform(transform),
+            origin: transform.transform_point3d(Point3D::origin())
+                .unwrap_or(Point3D::origin()).to_vector().to_untyped(),
+        }
+    }
+}


### PR DESCRIPTION
A quite messy PR which adds some basic Transform and Basis methods. I have been using these so that I can set a simple transform up in my code.

I would appreciate  if you could help get these into a state where they are suitable to merge. I really wanted to share them.

I am using code like this to instance a mesh, set up a transform and place it in the world

``` swift

    pub unsafe fn place_mesh(&mut self, pos: Vector3, scale: f32, rot: f32) -> Spatial {
        let mut instance = self.instance_tile();
        instance.set_name(GodotString::from_str(format!("({}, {})", pos.x as i32, pos.y as i32)));

        let transform =
            Transform3D::create_scale(scale, scale, scale)
                .post_rotate(0.0, 1.0, 0.0, Angle::degrees(rot))
                .post_translate(pos);

//        let transform = Transform

        instance.set_transform(Transform::from_transform(&transform));

        instance
    }

```

My process was to go to the relevant C++ code in the engine, port the code to Rust and put it in the object.