### PR TITLE
Add opt-in Instance downcasting support via tracking

### DIFF
--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 bitflags = "1.0"
 euclid = "0.19.6"
 parking_lot = "0.9.0"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 gdnative_bindings_generator = { path = "../bindings_generator", version = "0.2.0" }

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -31,6 +31,8 @@ pub extern crate libc;
 #[macro_use]
 extern crate bitflags;
 extern crate parking_lot;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod geom;
 

--- a/gdnative-core/src/user_data.rs
+++ b/gdnative-core/src/user_data.rs
@@ -32,6 +32,13 @@
 //! - You want fine grained lock control for parallelism.
 //! - All your exported methods take `&self`.
 //! - Your `NativeClass` type is `Send + Sync`.
+//!
+//! ### Use a `Tracked<_<T>>` when:
+//!
+//! - You want `FromVariant` for instances of the type, so you can take them as arguments.
+//! - You might have multiple GDNative libraries in one project, and want safety against foreign
+//!   `user_data`s that may point to arbitrary data or even invalid memory.
+//! - You're fine with a global lock on instance construction, destruction, and downcasts.
 
 use parking_lot::{Mutex, RwLock};
 use std::fmt::Debug;
@@ -90,9 +97,24 @@ pub trait MapMut: UserData {
         F: FnOnce(&mut Self::Target) -> U;
 }
 
+/// Trait for user-data wrappers that have a type-checked constructor.
+pub unsafe trait TryClone: UserData {
+    /// Checked version of "cloning" constructor. This is allowed to spuriously fail, but never
+    /// return an invalid result.
+    unsafe fn try_clone_from_user_data(ptr: *const libc::c_void) -> Option<Self>;
+}
+
+/// Marker trait for user-data wrappers that produce distinct pointers for each Godot instance.
+///
+/// There is no way for the compiler to test this property, so the trait is unsafe to implement.
+/// See documentation on `Tracked` for more information on why this is needed.
+pub unsafe trait UniquePtr: UserData {}
+
 /// The default user data wrapper used by derive macro, when no `user_data` attribute is present.
 /// This may change in the future.
 pub type DefaultUserData<T> = MutexData<T, DefaultLockPolicy>;
+
+pub use tracked::Tracked;
 
 /// Error type indicating that an operation can't fail.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -231,6 +253,13 @@ where
     }
 }
 
+unsafe impl<T, OPT> UniquePtr for MutexData<T, OPT>
+where
+    T: NativeClass + Send,
+    OPT: LockOptions,
+{
+}
+
 impl<T, OPT> Clone for MutexData<T, OPT> {
     fn clone(&self) -> Self {
         MutexData {
@@ -328,6 +357,13 @@ where
     }
 }
 
+unsafe impl<T, OPT> UniquePtr for RwLockData<T, OPT>
+where
+    T: NativeClass + Send + Sync,
+    OPT: LockOptions,
+{
+}
+
 impl<T, OPT> Clone for RwLockData<T, OPT> {
     fn clone(&self) -> Self {
         RwLockData {
@@ -381,8 +417,169 @@ where
     }
 }
 
+unsafe impl<T> UniquePtr for ArcData<T> where T: NativeClass + Send + Sync {}
+
 impl<T> Clone for ArcData<T> {
     fn clone(&self) -> Self {
         ArcData(self.0.clone())
+    }
+}
+
+mod tracked {
+    //! User-data wrapper adapter with type checking via tracking
+
+    use std::any::TypeId;
+    use std::collections::{HashMap, HashSet};
+
+    use parking_lot::RwLock;
+
+    use super::{Map, MapMut, TryClone, UniquePtr, UserData};
+
+    lazy_static! {
+        static ref TRACKED_POINTERS: RwLock<HashMap<TypeId, HashSet<usize>>> =
+            { RwLock::new(HashMap::new()) };
+    }
+
+    /// A `TryClone` user-data wrapper adapter that allows instance downcasting by tracking
+    /// user-data pointers in a global `HashMap`.
+    ///
+    /// The `HashMap` is accessed through an `RwLock` on construction, destruction, and downcasts.
+    /// There is no additional runtime cost on calls from Godot.
+    ///
+    /// The cast is incomplete, as in, not all valid values will pass the type check.
+    /// Specifically:
+    ///
+    /// - Null pointers will always fail to type check, despite being valid pointers for ZSTs.
+    ///   This is usually fine because user-data wrappers usually need some state, and are
+    ///   unlikely to produce a null pointer.
+    /// - If the user-data is consumed, then even if the wrapped data is not dropped yet, further
+    ///   attempts to check the same pointer will fail. This is fine because it can have no valid
+    ///   owner in this case.
+    /// - If multiple instances of the underlying wrapper produce the same user-data pointer,
+    ///   (e.g. a singleton, or a type that pulls values out of aether), then all further
+    ///   instances will fail to check by the time the first instance is consumed. To prevent
+    ///   this from happening, the marker trait `UniquePtr` is used as a bound on the inner
+    ///   wrapper. Violations of `UniquePtr`'s protocol will trigger debug assertions.
+    #[derive(Clone, Debug)]
+    pub struct Tracked<UD> {
+        data: UD,
+    }
+
+    unsafe impl<UD> UserData for Tracked<UD>
+    where
+        UD: UserData + UniquePtr,
+        UD::Target: 'static,
+    {
+        type Target = UD::Target;
+
+        fn new(val: Self::Target) -> Self {
+            // This only creates an instance owned by Rust, so no valid objects can exist yet.
+            Tracked { data: UD::new(val) }
+        }
+
+        unsafe fn into_user_data(self) -> *const libc::c_void {
+            let ptr = self.data.into_user_data() as *const libc::c_void;
+            {
+                // Only when the ownership is passed to Godot, does it become possible for an
+                // Godot object to be a valid instance of UD::Target. So, the pointer is added
+                // to the map at this point.
+                let mut ptr_map = TRACKED_POINTERS.write();
+                let ptrs = ptr_map
+                    .entry(TypeId::of::<UD::Target>())
+                    .or_insert_with(HashSet::new);
+                let ptr_is_new = ptrs.insert(ptr as usize);
+                debug_assert!(
+                    ptr_is_new,
+                    "pointer obtained from into_user_data should not be in the set"
+                );
+            }
+            ptr
+        }
+
+        unsafe fn consume_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+            {
+                // When the ownership is taken back from Godot, there can't be valid objects that
+                // should still be considered an instance of UD::Target. Thus, the pointer is
+                // removed from the map.
+                let mut ptr_map = TRACKED_POINTERS.write();
+                match ptr_map.get_mut(&TypeId::of::<UD::Target>()) {
+                    Some(ptrs) => {
+                        let ptr_is_there = ptrs.remove(&(ptr as usize));
+                        debug_assert!(ptr_is_there, "pointer should be in the set of UD::Target");
+                    }
+                    None => {
+                        debug_assert!(false, "pointer set should have been created by now");
+                    }
+                }
+            }
+            Tracked {
+                data: UD::consume_user_data_unchecked(ptr),
+            }
+        }
+
+        unsafe fn clone_from_user_data_unchecked(ptr: *const libc::c_void) -> Self {
+            Tracked {
+                data: UD::clone_from_user_data_unchecked(ptr),
+            }
+        }
+    }
+
+    impl<UD> Map for Tracked<UD>
+    where
+        UD: UserData + Map + UniquePtr,
+        UD::Target: 'static,
+    {
+        type Err = UD::Err;
+
+        fn map<F, U>(&self, op: F) -> Result<U, UD::Err>
+        where
+            F: FnOnce(&UD::Target) -> U,
+        {
+            self.data.map(op)
+        }
+    }
+
+    impl<UD> MapMut for Tracked<UD>
+    where
+        UD: UserData + MapMut + UniquePtr,
+        UD::Target: 'static,
+    {
+        type Err = UD::Err;
+
+        fn map_mut<F, U>(&self, op: F) -> Result<U, UD::Err>
+        where
+            F: FnOnce(&mut UD::Target) -> U,
+        {
+            self.data.map_mut(op)
+        }
+    }
+
+    unsafe impl<UD> TryClone for Tracked<UD>
+    where
+        UD: UserData + UniquePtr,
+        UD::Target: 'static,
+    {
+        unsafe fn try_clone_from_user_data(ptr: *const libc::c_void) -> Option<Self> {
+            if ptr.is_null() {
+                return None;
+            }
+
+            let result = {
+                let ptr_map = TRACKED_POINTERS.read();
+                let ptrs = ptr_map.get(&TypeId::of::<UD::Target>())?;
+
+                // The inner user data must be constructed before the read guard is dropped,
+                // because otherwise it might be consumed between the check and construction.
+                if ptrs.contains(&(ptr as usize)) {
+                    Some(Tracked {
+                        data: UD::clone_from_user_data_unchecked(ptr),
+                    })
+                } else {
+                    None
+                }
+            };
+
+            result
+        }
     }
 }


### PR DESCRIPTION
...also this thing which I've been dogfooding (albeit not very extensively yet) for a little while:

With customizable userdata merged, downcasting to NativeClass instances can now be supported with an opt-in userdata wrapper adaptor that performs pointer tracking, as described in the future possibilities section of the original Instance PR.

Tracking is performed only on construction, destruction, and downcasts, and only for types that opt-in. There is no additional runtime cost for calls from Godot.

Downcast attempts on types that are not tracked (or can otherwise be checked) are statically prevented.

# Explanation

The `Tracked<UD<T>>` type is a user-data wrapper adapter, which wraps around wrapper implementations, tracking the pointers they produce in a global `HashMap`:

- On `into_user_data`, the pointer is inserted into a set corresponding to the `TypeId` of the target type.
- On `consume_user_data_unchecked`, the pointer is removed.
- On `try_clone_from_user_data`, the map is queried with the given pointer. If the pointer is present in the set for the type, it's assumed to be valid. Otherwise, `None` is returned.

Like other locking types, it makes use of `parking_lot::RwLock` which is very efficient in uncontended situations. The map itself is a `lazy_static`, so it's not created at all if `Tracked` is unused.

Once `const_fn` is stablized, the `lazy_static` can be replaced with a `RwLock<Option<_>>` and initialized with a const `new`, removing the extra overhead.

# Drawbacks

I don't believe there is much except introducing more APIs in the crate, since it's purely opt-in. I think it's useful enough to warrant an addition, especially in cases where the code is expected to interact fairly often with GDScript. 

Also "user-data wrapper adapter" sounds like a tongue twister...

# Rationale and alternatives

## External interfaces

The use case for this overlaps a bit with #200, but with some key differences:

- For types defined in Rust, this allows much faster calls for a relatively cheap initial check, since it doesn't need to go through `Variant`.
- Meanwhile, external interfaces works with types defined in other languages.

I believe both features can co-exist serving different needs.

## `TypeId` tags

Instead of tracking pointers in a global map, it's also possible to store the `TypeId` beside the data, removing the need to perform locks and hash map lookups. This, however, poses its own problem when other GDNative libraries are in play.

As considered in the original `Instance` PR, the current implementation of `godot_nativescript_get_userdata` in Godot only checks that the script is *any* NativeScript: that is, not necessarily from this library or even language. Thus, it's well possible to read invalid data from a foreign pointer, or even cause segfaults in some cases (e.g. Rust ZSTs).

For projects where there will be only one GDNative library present, a tagged representation can be useful. Regardless, I consider it less fit for inclusion in the core library, because of the level of attention required in its use.