### PR TITLE
Support Instance downcasting with NativeScript 1.1 type tags

### DIFF
--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -106,6 +106,12 @@ impl InitHandle {
                 destroy,
             );
 
+            (get_api().godot_nativescript_set_type_tag)(
+                self.handle as *mut _,
+                class_name.as_ptr() as *const _,
+                crate::type_tag::create::<C>(),
+            );
+
             let mut builder = ClassBuilder {
                 init_handle: self.handle,
                 class_name,
@@ -172,6 +178,12 @@ impl InitHandle {
                 base_name.as_ptr() as *const _,
                 create,
                 destroy,
+            );
+
+            (get_api().godot_nativescript_set_type_tag)(
+                self.handle as *mut _,
+                class_name.as_ptr() as *const _,
+                crate::type_tag::create::<C>(),
             );
 
             let mut builder = ClassBuilder {

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod object;
 mod rid;
 mod string;
 mod string_array;
+mod type_tag;
 pub mod user_data;
 mod variant;
 mod variant_array;
@@ -104,6 +105,12 @@ pub fn get_api() -> &'static GodotApi {
 #[doc(hidden)]
 pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
     unsafe { GDNATIVE_LIBRARY_SYS.expect("GDNativeLibrary not bound") }
+}
+#[inline]
+#[doc(hidden)]
+pub unsafe fn cleanup_internal_state() {
+    type_tag::cleanup();
+    GODOT_API = None;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -84,7 +84,7 @@ macro_rules! godot_gdnative_terminate {
             $callback(options);
 
             unsafe {
-                $crate::GODOT_API = None;
+                $crate::cleanup_internal_state();
             }
         }
     };

--- a/gdnative-core/src/type_tag.rs
+++ b/gdnative-core/src/type_tag.rs
@@ -1,0 +1,104 @@
+use crate::NativeClass;
+use std::any::TypeId;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+struct Tag {
+    type_id: TypeId,
+}
+
+impl Tag {
+    fn of<T>() -> Self
+    where
+        T: NativeClass,
+    {
+        Tag {
+            type_id: TypeId::of::<T>(),
+        }
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+pub(crate) use self::boxed_type_tag::*;
+
+#[cfg(target_pointer_width = "64")]
+pub(crate) use self::transmuted_type_tag::*;
+
+/// Type tags implemented as boxed pointers. This is required for 32-bit targets because `size_t`
+/// is only 32-bits wide there, while `TypeId` is always 64-bit.
+#[cfg(target_pointer_width = "32")]
+mod boxed_type_tag {
+    use super::Tag;
+    use crate::NativeClass;
+    use std::boxed::Box;
+
+    /// Keep track of allocated type tags so they can be freed on cleanup
+    static mut TAGS: Option<Vec<*const Tag>> = None;
+
+    /// Create a new type tag for type `T`. This should only be called from `InitHandle`.
+    pub(crate) unsafe fn create<T>() -> *const libc::c_void
+    where
+        T: NativeClass,
+    {
+        // Safety: InitHandle is not Send or Sync, so this will only be called from one thread
+        let tags = TAGS.get_or_insert_with(Vec::new);
+        let type_tag = Box::into_raw(Box::new(Tag::of::<T>()));
+        tags.push(type_tag);
+        type_tag as *const libc::c_void
+    }
+
+    /// Returns `true` if `tag` corresponds to type `T`. `tag` must be one returned by `create`.
+    pub(crate) unsafe fn check<T>(tag: *const libc::c_void) -> bool
+    where
+        T: NativeClass,
+    {
+        Tag::of::<T>() == *(tag as *const Tag)
+    }
+
+    /// Perform any cleanup actions if required. Should only be called from
+    /// `crate::cleanup_internal_state`. `create` and `check` shouldn't be called after this.
+    pub(crate) unsafe fn cleanup() {
+        // Safety: By the time cleanup is called, create shouldn't be called again
+        if let Some(tags) = TAGS.take() {
+            for ptr in tags.into_iter() {
+                std::mem::drop(Box::from_raw(ptr as *mut Tag))
+            }
+        }
+    }
+}
+
+/// Type tags implemented as transmutes. This is faster on 64-bit targets, and require no
+/// allocation, as `TypeId` is `Copy`, and fits in a `size_t` there. This may break in the
+/// (probably very unlikely) event that:
+///
+/// - `TypeId`'s size changes (possible in Rust 1.x as `TypeId` is opaque).
+/// - `TypeId` loses `Copy` (only possible in Rust 2.0+).
+///
+/// Both will be compile errors: `transmute` should fail if the sizes mismatch, and the wrapper
+/// type `Tag` derives `Copy`.
+#[cfg(target_pointer_width = "64")]
+mod transmuted_type_tag {
+    use super::Tag;
+    use crate::NativeClass;
+
+    /// Create a new type tag for type `T`. This should only be called from `InitHandle`.
+    pub(crate) unsafe fn create<T>() -> *const libc::c_void
+    where
+        T: NativeClass,
+    {
+        std::mem::transmute::<Tag, *const libc::c_void>(Tag::of::<T>())
+    }
+
+    /// Returns `true` if `tag` corresponds to type `T`. `tag` must be one returned by `create`.
+    pub(crate) unsafe fn check<T>(tag: *const libc::c_void) -> bool
+    where
+        T: NativeClass,
+    {
+        Tag::of::<T>() == std::mem::transmute::<*const libc::c_void, Tag>(tag)
+    }
+
+    /// Perform any cleanup actions if required. Should only be called from
+    /// `crate::cleanup_internal_state`. `create` and `check` shouldn't be called after this.
+    pub(crate) unsafe fn cleanup() {
+        // do nothing
+    }
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -92,6 +92,20 @@ impl NativeClass for Foo {
     fn register_properties(_builder: &init::ClassBuilder<Self>) {}
 }
 
+struct NotFoo;
+
+impl NativeClass for NotFoo {
+    type Base = Reference;
+    type UserData = user_data::ArcData<NotFoo>;
+    fn class_name() -> &'static str {
+        "NotFoo"
+    }
+    fn init(_owner: Reference) -> NotFoo {
+        NotFoo
+    }
+    fn register_properties(_builder: &init::ClassBuilder<Self>) {}
+}
+
 #[methods]
 impl Foo {
     #[export]
@@ -130,11 +144,20 @@ fn test_rust_class_construction() -> bool {
 
     let ok = std::panic::catch_unwind(|| {
         let foo = Instance::<Foo>::new();
+
         assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
+
+        let mut base = foo.into_base();
         assert_eq!(
             Some(42),
-            unsafe { foo.into_base().call("answer".into(), &[]) }.try_to_i64()
+            unsafe { base.call("answer".into(), &[]) }.try_to_i64()
         );
+
+        let foo = Instance::<Foo>::try_from_base(base).expect("should be able to downcast");
+        assert_eq!(Ok(42), foo.map(|foo, owner| { foo.answer(owner) }));
+
+        let base = foo.into_base();
+        assert!(Instance::<NotFoo>::try_from_base(base).is_none());
     })
     .is_ok();
 


### PR DESCRIPTION
Type tags are transmuted from `TypeId`s on 64-bit targets, and boxed on 32-bit targets. This is fine, since we're using the scoped versions of the type tag API functions (`godot_nativescript_set_type_tag` / `godot_nativescript_get_type_tag`), and will only deal with values from within our own library.
    
As a limitation of `TypeId`, all instances of `NativeClass` are required to be `'static`. This should not be a problem, since Godot is not aware of lifetimes, and registering a non-`'static` class would be invalid anyway.

The transmutation may break in the (probably very unlikely) event that:

- `TypeId`'s size changes (possible in Rust 1.x as `TypeId` is opaque).
- `TypeId` loses `Copy` (only possible in Rust 2.0+).

Both will be compile errors, if they do happen against all odds: `transmute` should fail if the sizes mismatch, and the wrapper type `Tag` derives `Copy`.

# Drawbacks

- The theoretical possibility of breaking invalid programs that currently compile.

# Unresolved Questions

The 32-bit version can't currently be tested by CI, since there is not a 32-bit headless build for Godot. Travis also doen't have 32-bit system images.

It's possible to add a `force_boxed_type_tag` feature to enable testing of the boxed implementation on 64-bit platforms, but that will affect existing builds with all features enabled.