### PR TITLE
Add empty rustfmt.toml file, modify CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Have a look at the [issues](https://github.com/GodotNativeTools/godot-rust/issue
 
 - Whenever applicable, add tests relevant to the fixed bug or new feature.
 
+- Use `cargo fmt` to format your code.
+
 ## Testing
 
 - run `cargo test --all` from the root of the repository.


### PR DESCRIPTION
Now that rustfmt is part of the CI tests, it should be made clear that this repository makes use of automatic formatting.

The presence of a `rustfmt.toml` should indicate to potential contributors that they should run rustfmt before making a pull request.