### PR TITLE
disable cache on CI, remove some dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 
-cache: cargo
-
 matrix:
 
   allow_failures:

--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -14,6 +14,6 @@ edition = "2018"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = { version = "0.51.1", default-features = false }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This removes some optional dependencies from `bindgen` and disables cache on CI as this caused timeouts in the past.