### PR TITLE
Implement Variant conversion for tuples of arity 12 or less

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -27,6 +27,7 @@ pub extern "C" fn run_tests(
     status &= gdnative::test_variant_option();
     status &= gdnative::test_variant_result();
     status &= gdnative::test_to_variant_iter();
+    status &= gdnative::test_variant_tuple();
 
     status &= gdnative::test_byte_array_access();
     status &= gdnative::test_int32_array_access();


### PR DESCRIPTION
Behavior is consistent with tuple structs/variants.

Type parameter numbering does not start from `T1` for shorter tuples, but maintaining the "correct" ordering would make the code more convoluted, as macros can not normally match the last item off due to parser restrictions. It's also not really necessary in my opinion.