### PR TITLE
Add missing feature to syn dependency

### DIFF
--- a/gdnative-derive/Cargo.toml
+++ b/gdnative-derive/Cargo.toml
@@ -13,6 +13,6 @@ workspace = ".."
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "1.0", features = ["full", "extra-traits", "visit"] }
 quote = "1.0"
 proc-macro2 = "^1.0"


### PR DESCRIPTION
The `visit` module of `syn` is behind a non-default feature gate but that feature isn't specified in `gdnative-derive`'s Cargo.toml. This PR adds it.

There may be something here I'm not understanding because the project won't build (let alone run tests) for me locally without this flag but tests appear to be passing on Travis. Maybe Travis has a poisoned cache?