### PR TITLE
Add user data wrapper that does not require Send

### DIFF
--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -530,6 +530,7 @@ macro_rules! godot_wrap_method_inner {
                     Ok(val) => val.forget(),
                     Err(err) => {
                         godot_error!("gdnative-core: method call failed with error: {:?}", err);
+                        godot_error!("gdnative-core: check module level documentation on gdnative::user_data for more information");
                         $crate::Variant::new().to_sys()
                     }
                 }


### PR DESCRIPTION
Added `user_data::LocalCellData<T>`, a wrapper analogous to a `Arc<RefCell<T>>`. It does not require that the `NativeClass` inside be `Send`, but instead blocks all calls that are not from the original thread where the wrapper is created.

This may provide better semantics than manually implementing `Send` in cases where it's known in advance that an object will never be accessed from another thread.

## Should we make it the default wrapper?

Users writing "front-end" code directly in Rust need to keep references around, so there will be some friction with the current default, `MutexData`, which requires `Send`. Making `LocalCellData` the default will prevent situations like #226, where users get confused by error messages.

On the other hand, this will also make access from other threads a runtime error by default, which I think isn't very ideal. Would the added error message on map failure be enough for that case?

Alternatively, we can work on the documentation for the proc-macro, and hope that people will read it before writing code.