### PR TITLE
Remove type defaults from generics in derive macro

### DIFF
--- a/gdnative-derive/src/derive_conv_variant.rs
+++ b/gdnative-derive/src/derive_conv_variant.rs
@@ -341,8 +341,12 @@ pub(crate) fn derive_to_variant(input: TokenStream) -> TokenStream {
     let DeriveData {
         ident,
         repr,
-        generics,
+        mut generics,
     } = parse_derive_input(input, &bound);
+
+    for param in generics.type_params_mut() {
+        param.default = None;
+    }
 
     let return_expr = match repr {
         Repr::Struct(var_repr) => {
@@ -403,8 +407,12 @@ pub(crate) fn derive_from_variant(input: TokenStream) -> TokenStream {
     let DeriveData {
         ident,
         repr,
-        generics,
+        mut generics,
     } = parse_derive_input(input, &bound);
+
+    for param in generics.type_params_mut() {
+        param.default = None;
+    }
 
     let input_ident = Ident::new("__variant", Span::call_site());
 


### PR DESCRIPTION
When the Variant derive macros are used on types with defaults for type parameters, the defaults are contained in the generated impl blocks, triggering the `invalid-type-param-default` deny-by-default lint.

This PR drops the default types before generating code, which fixes the issue.