### PR TITLE
Call from_variant through trait for newtype variants in derive macro

### DIFF
--- a/gdnative-derive/src/derive_conv_variant.rs
+++ b/gdnative-derive/src/derive_conv_variant.rs
@@ -142,10 +142,9 @@ impl VariantRepr {
 
                 if types.len() == 1 {
                     // as newtype
-                    let inner = types.get(0).unwrap();
                     quote! {
                         {
-                            let __inner = #inner::from_variant(#variant)?;
+                            let __inner = FromVariant::from_variant(#variant)?;
                             Some(#ctor(__inner))
                         }
                     }


### PR DESCRIPTION
Fixes generated implementations for enum variants in the form of `Foo(Option<Bar>)`, which previous won't compile because the turbofish syntax is required to call the function. We could use `as_turbofish` to rewrite the type name, but naming the type is unnecessary.