### PR TITLE
Keep strings alive until signals are registered.

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -320,9 +320,37 @@ fn test_derive_to_variant() -> bool {
     ok
 }
 
+struct RegisterSignal;
+
+impl NativeClass for RegisterSignal {
+    type Base = Reference;
+    type UserData = user_data::ArcData<RegisterSignal>;
+    fn class_name() -> &'static str {
+        "RegisterSignal"
+    }
+    fn init(_owner: Reference) -> RegisterSignal {
+        RegisterSignal
+    }
+    fn register_properties(builder: &init::ClassBuilder<Self>) {
+        builder.add_signal(gdnative::init::Signal {
+            name: "progress",
+            args: &[gdnative::init::SignalArgument {
+                name: "amount",
+                default: gdnative::Variant::new(),
+                hint: gdnative::init::PropertyHint::None,
+                usage: gdnative::init::PropertyUsage::DEFAULT,
+            }],
+        });
+    }
+}
+
+#[methods]
+impl RegisterSignal {}
+
 fn init(handle: init::InitHandle) {
     handle.add_class::<Foo>();
     handle.add_class::<Bar>();
+    handle.add_class::<RegisterSignal>();
 }
 
 godot_gdnative_init!();


### PR DESCRIPTION
Fix #240.

On a side note, valgrind does report some extra errors with the `test_owner_free_ub` test, but on first glance they seem to be issues on Godot's side rather than ours. It seems like the engine doesn't handle freeing too well.

<details><summary>valgrind output</summary>
<p>

```
Invalid read of size 8
   at 0x29D2C63: StringName::unref() (string_name.cpp:99)
   by 0x29D2FA3: StringName::operator=(StringName const&) (string_name.cpp:159)
   by 0x852BF7: NativeScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (nativescript.cpp:743)
   by 0x2961EB0: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:921)
   by 0x29606E2: Object::_call_bind(Variant const**, int, Variant::CallError&) (object.cpp:678)
   by 0x2979058: MethodBindVarArg<Object>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.h:342)
   by 0x848C0E: godot_method_bind_call (gdnative.cpp:83)
   by 0x2D65553F: gdnative_core::generated::Object_call (core_methods.rs:295)
   by 0x2D5EB28F: gdnative_core::generated::Object::call (core_types.rs:101)
   by 0x2D5FC4F8: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:234)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
 Address 0x6f43298 is 40 bytes inside a block of size 56 free'd
   at 0x4D039AB: free (vg_replace_malloc.c:540)
   by 0x295EB5A: memdelete<ScriptInstance> (memory.h:122)
   by 0x295EB5A: Object::set_script(RefPtr const&) (object.cpp:999)
   by 0x29773FF: MethodBind1<Object, RefPtr const&>::ptrcall(Object*, void const**, void*) (method_bind.gen.inc:824)
   by 0x2D655785: gdnative_core::generated::Object_set_script (core_methods.rs:946)
   by 0x2D5EB238: gdnative_core::generated::Object::set_script (core_types.rs:271)
   by 0x2D5F2B9D: gdnative_test::Bar::set_script_is_not_ub (lib.rs:206)
   by 0x2D5FE20C: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}}::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:43)
   by 0x2D5F8407: gdnative_core::class::Instance<T>::map_mut_aliased::{{closure}} (class.rs:270)
   by 0x2D5E905D: <gdnative_core::user_data::RwLockData<T,OPT> as gdnative_core::user_data::MapMut>::map_mut (user_data.rs:332)
   by 0x2D5F80F3: gdnative_core::class::Instance<T>::map_mut_aliased (class.rs:269)
   by 0x2D5FE265: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:40)
   by 0x2D5E68D3: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once (panic.rs:315)
 Block was alloc'd at
   at 0x4D0277F: malloc (vg_replace_malloc.c:309)
   by 0x2AEF3BF: alloc_static (memory.cpp:85)
   by 0x2AEF3BF: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x84FAFA: NativeScript::instance_create(Object*) (nativescript.cpp:204)
   by 0x295EBB2: Object::set_script(RefPtr const&) (object.cpp:1009)
   by 0x29773FF: MethodBind1<Object, RefPtr const&>::ptrcall(Object*, void const**, void*) (method_bind.gen.inc:824)
   by 0x2D5F9A34: gdnative_core::class::Instance<T>::new (class.rs:134)
   by 0x2D5FC3A2: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:227)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
   by 0x2D602774: std::panicking::try (panicking.rs:275)
   by 0x2D5E6A28: std::panic::catch_unwind (panic.rs:394)
   by 0x2D5EC42C: gdnative_test::test_owner_free_ub (lib.rs:224)

Invalid write of size 8
   at 0x29D2D26: StringName::unref() (string_name.cpp:119)
   by 0x29D2FA3: StringName::operator=(StringName const&) (string_name.cpp:159)
   by 0x852BF7: NativeScriptInstance::call(StringName const&, Variant const**, int, Variant::CallError&) (nativescript.cpp:743)
   by 0x2961EB0: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:921)
   by 0x29606E2: Object::_call_bind(Variant const**, int, Variant::CallError&) (object.cpp:678)
   by 0x2979058: MethodBindVarArg<Object>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.h:342)
   by 0x848C0E: godot_method_bind_call (gdnative.cpp:83)
   by 0x2D65553F: gdnative_core::generated::Object_call (core_methods.rs:295)
   by 0x2D5EB28F: gdnative_core::generated::Object::call (core_types.rs:101)
   by 0x2D5FC4F8: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:234)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
 Address 0x6f43298 is 40 bytes inside a block of size 56 free'd
   at 0x4D039AB: free (vg_replace_malloc.c:540)
   by 0x295EB5A: memdelete<ScriptInstance> (memory.h:122)
   by 0x295EB5A: Object::set_script(RefPtr const&) (object.cpp:999)
   by 0x29773FF: MethodBind1<Object, RefPtr const&>::ptrcall(Object*, void const**, void*) (method_bind.gen.inc:824)
   by 0x2D655785: gdnative_core::generated::Object_set_script (core_methods.rs:946)
   by 0x2D5EB238: gdnative_core::generated::Object::set_script (core_types.rs:271)
   by 0x2D5F2B9D: gdnative_test::Bar::set_script_is_not_ub (lib.rs:206)
   by 0x2D5FE20C: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}}::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:43)
   by 0x2D5F8407: gdnative_core::class::Instance<T>::map_mut_aliased::{{closure}} (class.rs:270)
   by 0x2D5E905D: <gdnative_core::user_data::RwLockData<T,OPT> as gdnative_core::user_data::MapMut>::map_mut (user_data.rs:332)
   by 0x2D5F80F3: gdnative_core::class::Instance<T>::map_mut_aliased (class.rs:269)
   by 0x2D5FE265: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:40)
   by 0x2D5E68D3: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once (panic.rs:315)
 Block was alloc'd at
   at 0x4D0277F: malloc (vg_replace_malloc.c:309)
   by 0x2AEF3BF: alloc_static (memory.cpp:85)
   by 0x2AEF3BF: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x84FAFA: NativeScript::instance_create(Object*) (nativescript.cpp:204)
   by 0x295EBB2: Object::set_script(RefPtr const&) (object.cpp:1009)
   by 0x29773FF: MethodBind1<Object, RefPtr const&>::ptrcall(Object*, void const**, void*) (method_bind.gen.inc:824)
   by 0x2D5F9A34: gdnative_core::class::Instance<T>::new (class.rs:134)
   by 0x2D5FC3A2: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:227)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
   by 0x2D602774: std::panicking::try (panicking.rs:275)
   by 0x2D5E6A28: std::panic::catch_unwind (panic.rs:394)
   by 0x2D5EC42C: gdnative_test::test_owner_free_ub (lib.rs:224)

Invalid read of size 4
   at 0x296208C: atomic_decrement<unsigned int> (safe_refcount.h:118)
   by 0x296208C: unref (safe_refcount.h:192)
   by 0x296208C: ~_ObjectDebugLock (object.cpp:53)
   by 0x296208C: Object::call(StringName const&, Variant const**, int, Variant::CallError&) (object.cpp:948)
   by 0x29606E2: Object::_call_bind(Variant const**, int, Variant::CallError&) (object.cpp:678)
   by 0x2979058: MethodBindVarArg<Object>::call(Object*, Variant const**, int, Variant::CallError&) (method_bind.h:342)
   by 0x848C0E: godot_method_bind_call (gdnative.cpp:83)
   by 0x2D65553F: gdnative_core::generated::Object_call (core_methods.rs:295)
   by 0x2D5EB28F: gdnative_core::generated::Object::call (core_types.rs:101)
   by 0x2D5FC860: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:245)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
   by 0x2D602774: std::panicking::try (panicking.rs:275)
   by 0x2D5E6A28: std::panic::catch_unwind (panic.rs:394)
   by 0x2D5EC42C: gdnative_test::test_owner_free_ub (lib.rs:224)
 Address 0xa813560 is 48 bytes inside a block of size 536 free'd
   at 0x4D039AB: free (vg_replace_malloc.c:540)
   by 0x2D6039D5: gdnative_bindings::Node::free (bindings_types.rs:43116)
   by 0x2D5F297A: gdnative_test::Bar::free_is_not_ub (lib.rs:197)
   by 0x2D5FE0EC: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}}::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:43)
   by 0x2D5F8267: gdnative_core::class::Instance<T>::map_mut_aliased::{{closure}} (class.rs:270)
   by 0x2D5E8C2D: <gdnative_core::user_data::RwLockData<T,OPT> as gdnative_core::user_data::MapMut>::map_mut (user_data.rs:332)
   by 0x2D5F7FF3: gdnative_core::class::Instance<T>::map_mut_aliased (class.rs:269)
   by 0x2D5FE145: <gdnative_test::Bar as gdnative_core::class::NativeClassMethods>::register::method::{{closure}} (<::gdnative_core::macros::godot_wrap_method_inner macros>:40)
   by 0x2D5E6953: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once (panic.rs:315)
   by 0x2D603704: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
   by 0x2D602B05: std::panicking::try (panicking.rs:275)
 Block was alloc'd at
   at 0x4D0277F: malloc (vg_replace_malloc.c:309)
   by 0x2AEF3BF: alloc_static (memory.cpp:85)
   by 0x2AEF3BF: operator new(unsigned long, char const*) (memory.cpp:42)
   by 0x18F1FE1: Object* ClassDB::creator<Node>() (class_db.h:146)
   by 0x2D603CF4: gdnative_bindings::Node::new (bindings_types.rs:43105)
   by 0x2D603E56: <gdnative_bindings::Node as gdnative_core::object::Instanciable>::construct (bindings_traits.rs:15290)
   by 0x2D5F96E0: gdnative_core::class::Instance<T>::new (class.rs:125)
   by 0x2D5FC722: gdnative_test::test_owner_free_ub::{{closure}} (lib.rs:239)
   by 0x2D6036AD: std::panicking::try::do_call (panicking.rs:296)
   by 0x2D69D669: __rust_maybe_catch_panic (lib.rs:80)
   by 0x2D602774: std::panicking::try (panicking.rs:275)
   by 0x2D5E6A28: std::panic::catch_unwind (panic.rs:394)
   by 0x2D5EC42C: gdnative_test::test_owner_free_ub (lib.rs:224)
```

</p>
</details>