### PR TITLE
Remove Copy from GodotApi

### DIFF
--- a/gdnative-sys/src/api.rs
+++ b/gdnative-sys/src/api.rs
@@ -23,7 +23,7 @@ struct GodotApi {
     }
 }
     ) => (
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct GodotApi {
     $(
     $(


### PR DESCRIPTION
The size of the `GodotApi` struct is currently 6528 bytes, making it obviously non-trivial to copy. It should be beneficial to remove the `Copy` implementation to prevent accidental copying when writing future library code.