### PR TITLE
Add logging crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gdnative-derive",
     "gdnative-core",
     "gdnative-bindings",
+    "gdnative-log",
     "test",
     "bindings_generator",
     "examples/hello_world",

--- a/gdnative-log/Cargo.toml
+++ b/gdnative-log/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gdnative-log"
+version = "0.1.0"
+authors = ["Chris Williams <chris@chrispwill.com>"]
+edition = "2018"
+
+[dependencies]
+log = { version = "^0.4.8", features = ["std"] }
+gdnative-core = { path = "../gdnative-core", version = "0.5.0" }

--- a/gdnative-log/src/lib.rs
+++ b/gdnative-log/src/lib.rs
@@ -8,7 +8,8 @@
 #[macro_use]
 extern crate gdnative_core;
 
-use log::{self, Level, Metadata, Record, SetLoggerError};
+pub use log::Level;
+use log::{self, Metadata, Record, SetLoggerError};
 
 struct GodotLogger {
     level: Level,

--- a/gdnative-log/src/lib.rs
+++ b/gdnative-log/src/lib.rs
@@ -1,0 +1,67 @@
+//! # Adapter for the Rust log crate
+//!
+//! This crate writes an adapter for the Rust log crate such that logging statements
+//! get output on the Godot console. Essentially it translates `error!()`, `info!()`
+//! and so on into the appropriate `godot_error!()`, `godot_warn!()` and
+//! `godot_print()` calls.
+
+#[macro_use]
+extern crate gdnative_core;
+
+use log::{self, Level, Metadata, Record, SetLoggerError};
+
+struct GodotLogger {
+    level: Level,
+}
+
+impl log::Log for GodotLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            match record.level() {
+                Level::Warn => godot_warn!("{} - {}", record.level(), record.args()),
+                Level::Error => godot_error!("{} - {}", record.level(), record.args()),
+                _ => godot_print!("{} - {}", record.level(), record.args()),
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Initialises the logger with the warning level set.
+///
+/// ```ignore
+/// # #[macro_use] extern crate log;
+/// #
+/// # fn main() {
+/// gdnative::init_logging_with_level(log::Level::Warn).unwrap();
+///
+/// warn!("This will be logged as a warning.");
+/// info!("This message will not be logged.");
+/// # }
+/// ```
+pub fn init_logging_with_level(level: Level) -> Result<(), SetLoggerError> {
+    let logger = GodotLogger { level };
+    log::set_boxed_logger(Box::new(logger))?;
+    log::set_max_level(level.to_level_filter());
+    Ok(())
+}
+
+/// Initialises the logger with warning level defaulted to `Level::Trace`
+///
+/// ```ignore
+/// # #[macro_use] extern crate log;
+/// #
+/// # fn main() {
+/// gdnative::init_logging().unwrap();
+///
+/// warn!("This will be logged as a warning.");
+/// # }
+/// ```
+pub fn init_logging() -> Result<(), SetLoggerError> {
+    init_logging_with_level(Level::Trace)
+}

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -14,11 +14,13 @@ default = ["bindings"]
 
 gd_test = ["gdnative-core/gd_test"]
 bindings = ["gdnative-bindings"]
+log = ["gdnative-log"]
 
 [dependencies]
 gdnative-derive = { path = "../gdnative-derive", version = "0.5.0" }
 gdnative-core = { path = "../gdnative-core", version = "0.5.0" }
 gdnative-bindings = { optional = true, path = "../gdnative-bindings" }
+gdnative-log = { optional = true, path = "../gdnative-log" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -40,3 +40,7 @@ pub use gdnative_derive::*;
 #[doc(inline)]
 #[cfg(feature = "bindings")]
 pub use gdnative_bindings::*;
+
+#[doc(inline)]
+#[cfg(feature = "log")]
+pub use gdnative_log::*;


### PR DESCRIPTION
This adds a crate that acts as an adapter for the macros from the Rust [log](https://github.com/rust-lang/log) crate to call the appropriate `godot_x!()` function. Allowing the logging macros to send messages to the Godot console is as simple as doing:

```
use gdnative;

// Shows all log levels
gdnative::init_logging();
```

or

```
use gdnative;
use log::Level;

// Logs only `Warn` level and higher
gdnative::init_logging_with_level(Level::Warn);
```

at the top of your `_init()` function.