### PR TITLE
Point users to the git version until 0.7.0 can be released

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,18 @@ Starting with an empty Godot project, a `cargo` project can be created inside th
 cargo init --lib
 ```
 
-To use the GDNative bindings in your project you have to add the `gdnative` crate as a dependency.
+To use the GDNative bindings in your project you have to add the `gdnative` crate as a dependency. The crates.io version of the bindings is very out of date, and it's currently preferred to use the `master` branch instead until a new release is made.
 
 ```toml
 [dependencies]
-gdnative = "0.5.0"
+gdnative = { git = "git://github.com/GodotNativeTools/godot-rust" }
+```
+
+You may also vendor the bindings as a local dependency:
+
+```toml
+[dependencies]
+gdnative = { path = "../godot-rust" }
 ```
 
 Since GDNative can only use C-compatible dynamic libraries, the crate type has to be set accordingly.


### PR DESCRIPTION
The 0.7.0 release is currently put on a indeterminate delay. To prevent confusion from new users, the example in README should use the git version as the dependency instead.

There are currently multiple open issues on this matter:

Close #162. Close #137. Close #166. Close #206.