### PR TITLE
Fix early dropping of Option<Object> parameters

### DIFF
--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -417,7 +417,7 @@ fn generate_argument_pre(w: &mut impl Write, ty: &Ty, name: &str) -> GeneratorRe
             )?;
         }
         &Ty::Object(_) => {
-            writeln!(w, r#"        if let Some(arg) = {name} {{ arg.this as *const _ as *const _ }} else {{ ptr::null() }},"#,
+            writeln!(w, r#"        if let Some(arg) = &{name} {{ arg.this as *const _ as *const _ }} else {{ ptr::null() }},"#,
                 name = name,
             )?;
         }


### PR DESCRIPTION
See issue #257.

Rust inserts a drop() because the `Option<Object>` is moved into the pattern match. This caused the `Object` (`Ref<Image>` in the case of issue #257) to be NULL once Godot tried to use the value.

Adding a borrow causes the value to live as long as the function, by which point we have transferred ownership of the `Object` to Godot.