### PR TITLE
Additional helper methods for Vector2 and Point2

### DIFF
--- a/gdnative-core/src/geom/mod.rs
+++ b/gdnative-core/src/geom/mod.rs
@@ -5,11 +5,16 @@ mod basis;
 mod plane;
 mod transform;
 
-pub type Vector3 = euclid::Vector3D<f32, euclid::UnknownUnit>;
-pub type Vector2 = euclid::Vector2D<f32, euclid::UnknownUnit>;
-pub type Transform2D = euclid::Transform2D<f32, euclid::UnknownUnit, euclid::UnknownUnit>;
-pub type Quat = euclid::Rotation3D<f32, euclid::UnknownUnit, euclid::UnknownUnit>;
-pub type Rect2 = euclid::Rect<f32, euclid::UnknownUnit>;
+pub type Vector3 = euclid::default::Vector3D<f32>;
+pub type Vector2 = euclid::default::Vector2D<f32>;
+pub type Transform2D = euclid::default::Transform2D<f32>;
+pub type Quat = euclid::default::Rotation3D<f32>;
+pub type Rect2 = euclid::default::Rect<f32>;
+pub type Angle = euclid::Angle<f32>;
+pub type Point3 = euclid::default::Point3D<f32>;
+pub type Point2 = euclid::default::Point2D<f32>;
+pub type Rotation2D = euclid::default::Rotation2D<f32>;
+pub type Rotation3D = euclid::default::Rotation3D<f32>;
 
 pub use self::aabb::Aabb;
 pub use self::basis::Basis;

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -50,6 +50,7 @@ mod int32_array;
 mod node_path;
 #[doc(hidden)]
 pub mod object;
+mod point2;
 mod rid;
 mod string;
 mod string_array;
@@ -75,6 +76,7 @@ pub use crate::int32_array::*;
 pub use crate::node_path::*;
 pub use crate::object::GodotObject;
 pub use crate::object::Instanciable;
+pub use crate::point2::*;
 pub use crate::rid::*;
 pub use crate::string::*;
 pub use crate::string_array::*;

--- a/gdnative-core/src/point2.rs
+++ b/gdnative-core/src/point2.rs
@@ -1,0 +1,41 @@
+use crate::{Angle, Point2, Vector2};
+use euclid::Trig;
+
+/// Helper methods for `Point2`.
+///
+/// Trait used to provide additional methods that are equivalent to Godot's methods.
+/// See the official [`Godot documentation`](https://docs.godotengine.org/en/3.1/classes/class_vector2.html).
+pub trait Point2Godot {
+    /// Returns the angle in radians between the line connecting the two points and the x
+    /// coordinate.
+    fn angle_to_point(self, other: Point2) -> Angle;
+    /// Returns the normalized vector pointing from this point to `other`.
+    fn direction_to(self, other: Point2) -> Vector2;
+    /// Returns the distance to `other`.
+    fn distance_to(self, other: Point2) -> f32;
+    /// Returns the squared distance to `other`. Prefer this function over distance_to if you
+    /// need to sort points or need the squared distance for some formula.
+    fn distance_squared_to(self, other: Point2) -> f32;
+}
+
+impl Point2Godot for Point2 {
+    #[inline]
+    fn angle_to_point(self, other: Point2) -> Angle {
+        Angle::radians(Trig::fast_atan2(self.y - other.y, self.x - other.x))
+    }
+
+    #[inline]
+    fn direction_to(self, other: Point2) -> Vector2 {
+        (other - self).normalize()
+    }
+
+    #[inline]
+    fn distance_to(self, other: Point2) -> f32 {
+        (other - self).length()
+    }
+
+    #[inline]
+    fn distance_squared_to(self, other: Point2) -> f32 {
+        (other - self).square_length()
+    }
+}

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -1,7 +1,5 @@
-use crate::FromVariant;
-use crate::ToVariant;
-use crate::Variant;
-use crate::Vector2;
+use crate::{Angle, Rotation2D, Vector2};
+use crate::{FromVariant, ToVariant, Variant};
 
 impl ToVariant for Vector2 {
     fn to_variant(&self) -> Variant {
@@ -12,6 +10,83 @@ impl ToVariant for Vector2 {
 impl FromVariant for Vector2 {
     fn from_variant(variant: &Variant) -> Option<Self> {
         variant.try_to_vector2()
+    }
+}
+
+/// Helper methods for `Vector2`.
+///
+/// Trait used to provide additional methods that are equivalent to Godot's methods.
+/// See the official [`Godot documentation`](https://docs.godotengine.org/en/3.1/classes/class_vector2.html).
+pub trait Vector2Godot {
+    /// Returns the ratio of x to y.
+    fn aspect(self) -> f32;
+    /// Cubicly interpolates between this vector and `b` using `pre_a` and `post_b` as handles,
+    /// and returns the result at position `t`. `t` is in the range of 0.0 - 1.0, representing
+    /// the amount of interpolation.
+    fn cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, t: f32) -> Self;
+    /// Returns the vector rotated by `angle` radians.
+    fn rotated(self, angle: Angle) -> Self;
+    /// Returns the component of the vector along a plane defined by the given normal.
+    fn slide(self, normal: Self) -> Self;
+    /// Returns the vector snapped to a grid with the given size.
+    fn snapped(self, by: Self) -> Self;
+    /// Returns a perpendicular vector.
+    fn tangent(self) -> Self;
+}
+
+impl Vector2Godot for Vector2 {
+    #[inline]
+    fn aspect(self) -> f32 {
+        self.x / self.y
+    }
+
+    #[inline]
+    fn cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, t: f32) -> Self {
+        let v0 = pre_a;
+        let v1 = self;
+        let v2 = b;
+        let v3 = post_b;
+
+        let t2 = t * t;
+        let t3 = t2 * t;
+
+        ((v1 * 2.0)
+            + (-v0 + v2) * t
+            + (v0 * 2.0 - v1 * 5.0 + v2 * 4.0 - v3) * t2
+            + (-v0 + v1 * 3.0 - v2 * 3.0 + v3) * t3)
+            * 0.5
+    }
+
+    #[inline]
+    fn rotated(self, angle: Angle) -> Self {
+        let r = Rotation2D::new(angle);
+        r.transform_vector(self)
+    }
+
+    #[inline]
+    fn slide(self, normal: Self) -> Self {
+        self - normal * self.dot(normal)
+    }
+
+    #[inline]
+    fn snapped(self, by: Self) -> Self {
+        Vector2::new(
+            if by.x != 0.0 {
+                (self.x / by.x + 0.5).floor() * by.x
+            } else {
+                self.x
+            },
+            if by.y != 0.0 {
+                (self.y / by.y + 0.5).floor() * by.y
+            } else {
+                self.y
+            },
+        )
+    }
+
+    #[inline]
+    fn tangent(self) -> Self {
+        Vector2::new(self.y, -self.x)
     }
 }
 
@@ -46,7 +121,8 @@ godot_test!(
 
 #[cfg(test)]
 mod tests {
-    use super::Vector2;
+    use crate::vector2::Vector2Godot;
+    use crate::Vector2;
 
     #[test]
     fn it_is_copy() {
@@ -68,5 +144,69 @@ mod tests {
     #[test]
     fn it_supports_inequality() {
         assert_ne!(Vector2::new(1.0, 10.0), Vector2::new(1.0, 2.0));
+    }
+
+    #[test]
+    fn cubic_interpolate_is_sane() {
+        use euclid::approxeq::ApproxEq;
+        use Vector2 as V;
+
+        assert!(
+            V::new(4.7328, -6.7936).approx_eq(&V::new(5.4, -6.8).cubic_interpolate(
+                V::new(-1.2, 0.8),
+                V::new(1.2, 10.3),
+                V::new(-5.4, 4.2),
+                0.2
+            ))
+        );
+
+        assert!(
+            V::new(-3.8376, 2.9384).approx_eq(&V::new(-4.2, 1.4).cubic_interpolate(
+                V::new(-3.7, 2.1),
+                V::new(5.4, -8.5),
+                V::new(-10.8, -6.6),
+                0.6
+            ))
+        );
+    }
+
+    #[test]
+    fn slide_is_sane() {
+        use euclid::approxeq::ApproxEq;
+        use Vector2 as V;
+
+        let cases = &[
+            (V::new(1.0, 1.0), V::new(0.0, 1.0), V::new(1.0, 0.0)),
+            (
+                V::new(3.0, 4.0),
+                V::new(-3.0, 1.0).normalize(),
+                V::new(1.5, 4.5),
+            ),
+            (
+                V::new(-2.0, 1.0),
+                V::new(-1.0, 3.0).normalize(),
+                V::new(-1.5, -0.5),
+            ),
+        ];
+
+        for &(v, normal, expected) in cases {
+            assert!(expected.approx_eq(&v.slide(normal)));
+        }
+    }
+
+    #[test]
+    fn snapped_is_sane() {
+        use euclid::approxeq::ApproxEq;
+        use Vector2 as V;
+
+        let cases = &[
+            (V::new(1.5, 5.6), V::new(1.0, 4.0), V::new(2.0, 4.0)),
+            (V::new(5.4, 4.2), V::new(-2.0, -3.5), V::new(6.0, 3.5)),
+            (V::new(5.4, -6.8), V::new(0.0, 0.3), V::new(5.4, -6.9)),
+        ];
+
+        for &(v, by, expected) in cases {
+            assert!(expected.approx_eq(&v.snapped(by)));
+        }
     }
 }


### PR DESCRIPTION
Added the extension traits `Vector2Godot` and `Point2Godot`, implementing some helper methods not available in `euclid`. Type aliases are defined for `Point` and `Rotation`.

Supersedes #218. Credits to @bakamomi.