### PR TITLE
Handle new problematic enums in Godot 3.2 beta

### DIFF
--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -91,7 +91,7 @@ pub type ConstantValue = i64;
 #[derive(Deserialize, Debug)]
 pub struct Enum {
     pub name: String,
-    pub values: HashMap<String, u32>,
+    pub values: HashMap<String, i64>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
New enums with duplicate and negative values broke generation. The following changes are made to fix it:

- Special cases are added for `CameraServer.FeedImage`
- Duplicate enum variants that are not manually special-cased are automatically skipped with warnings.
- Negative enum values are allowed to parse as `i64`s, similar to associated constants, but casted to `u32` in order to preserve stability of explicit `repr`. Associated constants are not affected.

Unfortunately, CI tests can't currently be added for Godot 3.1.2-stable and 3.2-beta4, since the headless versions seem to be unable to generate API JSONs. See travis log https://travis-ci.org/GodotNativeTools/godot-rust/jobs/628307136:

> $ if [[ "$CI_GENERATE_API_JSON" == "yes" ]]; then "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --gdnative-generate-json-api bindings_generator/api.json; fi
> pure virtual method called
> terminate called without an active exception
> /home/travis/.travis/functions: line 109:  3638 Aborted                 (core dumped) "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --gdnative-generate-json-api bindings_generator/api.json
> The command "if [[ "$CI_GENERATE_API_JSON" == "yes" ]]; then "Godot_v${GODOT_VER}-${GODOT_REL}_linux_headless.64" --gdnative-generate-json-api bindings_generator/api.json; fi" exited with 134.

Fix #262
