### PR TITLE
FromVariant error refinement

### DIFF
--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -105,7 +105,7 @@ impl ToVariant for {name} {{
     fn to_variant(&self) -> Variant {{ Variant::from_object(self) }}
 }}
 impl FromVariant for {name} {{
-    fn from_variant(variant: &Variant) -> Option<Self> {{ variant.try_to_object::<Self>() }}
+    fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {{ variant.try_to_object_with_error::<Self>() }}
 }}"#,
         name = class.name,
         addref_if_reference = if class.is_refcounted() {

--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -130,12 +129,6 @@ impl_basic_traits!(
 impl ToVariant for ByteArray {
     fn to_variant(&self) -> Variant {
         Variant::from_byte_array(self)
-    }
-}
-
-impl FromVariant for ByteArray {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_byte_array()
     }
 }
 

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -2,6 +2,7 @@ use crate::get_api;
 use crate::object;
 use crate::sys;
 use crate::FromVariant;
+use crate::FromVariantError;
 use crate::GodotObject;
 use crate::GodotString;
 use crate::Instanciable;
@@ -314,9 +315,11 @@ where
     T: NativeClass,
     T::Base: FromVariant + Clone,
 {
-    fn from_variant(variant: &Variant) -> Option<Self> {
+    fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
         let owner = T::Base::from_variant(variant)?;
-        Self::try_from_base(owner)
+        Self::try_from_base(owner).ok_or(FromVariantError::InvalidInstance {
+            expected: T::class_name(),
+        })
     }
 }
 

--- a/gdnative-core/src/color.rs
+++ b/gdnative-core/src/color.rs
@@ -36,6 +36,11 @@ impl Color {
     pub fn v(&self) -> f32 {
         unsafe { (get_api().godot_color_get_v)(self.as_sys_color()) }
     }
+
+    #[doc(hidden)]
+    pub fn from_sys(c: sys::godot_color) -> Self {
+        unsafe { transmute::<sys::godot_color, Self>(c) }
+    }
 }
 
 #[test]

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -2,7 +2,6 @@ use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
 use crate::Color;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -134,12 +133,6 @@ impl_basic_traits!(
 impl ToVariant for ColorArray {
     fn to_variant(&self) -> Variant {
         Variant::from_color_array(self)
-    }
-}
-
-impl FromVariant for ColorArray {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_color_array()
     }
 }
 

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -1,6 +1,5 @@
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::GodotString;
 use crate::ToVariant;
 use crate::Variant;
@@ -126,12 +125,6 @@ impl_basic_traits!(
 impl ToVariant for Dictionary {
     fn to_variant(&self) -> Variant {
         Variant::from_dictionary(self)
-    }
-}
-
-impl FromVariant for Dictionary {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_dictionary()
     }
 }
 

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -130,12 +129,6 @@ impl_basic_traits!(
 impl ToVariant for Float32Array {
     fn to_variant(&self) -> Variant {
         Variant::from_float32_array(self)
-    }
-}
-
-impl FromVariant for Float32Array {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_float32_array()
     }
 }
 

--- a/gdnative-core/src/geom/aabb.rs
+++ b/gdnative-core/src/geom/aabb.rs
@@ -7,3 +7,10 @@ pub struct Aabb {
     pub position: Vector3,
     pub size: Vector3,
 }
+
+impl Aabb {
+    #[doc(hidden)]
+    pub fn from_sys(c: sys::godot_aabb) -> Self {
+        unsafe { std::mem::transmute::<sys::godot_aabb, Self>(c) }
+    }
+}

--- a/gdnative-core/src/geom/basis.rs
+++ b/gdnative-core/src/geom/basis.rs
@@ -7,4 +7,9 @@ pub struct Basis {
     pub elements: [Vector3; 3],
 }
 
-// TODO methods!
+impl Basis {
+    #[doc(hidden)]
+    pub fn from_sys(c: sys::godot_basis) -> Self {
+        unsafe { std::mem::transmute::<sys::godot_basis, Self>(c) }
+    }
+}

--- a/gdnative-core/src/geom/plane.rs
+++ b/gdnative-core/src/geom/plane.rs
@@ -7,3 +7,10 @@ pub struct Plane {
     pub normal: Vector3,
     pub d: f32,
 }
+
+impl Plane {
+    #[doc(hidden)]
+    pub fn from_sys(c: sys::godot_plane) -> Self {
+        unsafe { std::mem::transmute::<sys::godot_plane, Self>(c) }
+    }
+}

--- a/gdnative-core/src/geom/transform.rs
+++ b/gdnative-core/src/geom/transform.rs
@@ -12,4 +12,9 @@ pub struct Transform {
     pub origin: Vector3,
 }
 
-// TODO: methods!
+impl Transform {
+    #[doc(hidden)]
+    pub fn from_sys(c: sys::godot_transform) -> Self {
+        unsafe { std::mem::transmute::<sys::godot_transform, Self>(c) }
+    }
+}

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -564,12 +564,15 @@ where
                 let rust_ty = C::UserData::clone_from_user_data_unchecked(class as *const _);
                 let func = &mut *(method as *mut F);
 
-                if let Some(val) = T::from_variant(Variant::cast_ref(val)) {
-                    if let Err(err) = rust_ty.map_mut(|rust_ty| func(rust_ty, val)) {
-                        godot_error!("gdnative-core: cannot call property setter: {:?}", err);
+                match T::from_variant(Variant::cast_ref(val)) {
+                    Ok(val) => {
+                        if let Err(err) = rust_ty.map_mut(|rust_ty| func(rust_ty, val)) {
+                            godot_error!("gdnative-core: cannot call property setter: {:?}", err);
+                        }
                     }
-                } else {
-                    godot_error!("Incorrect type passed to property");
+                    Err(err) => {
+                        godot_error!("Incorrect type passed to property: {}", err);
+                    }
                 }
             }
         }

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -130,12 +129,6 @@ impl_basic_traits!(
 impl ToVariant for Int32Array {
     fn to_variant(&self) -> Variant {
         Variant::from_int32_array(self)
-    }
-}
-
-impl FromVariant for Int32Array {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_int32_array()
     }
 }
 

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -1,6 +1,5 @@
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::GodotString;
 use crate::ToVariant;
 use crate::Variant;
@@ -148,12 +147,6 @@ impl_basic_traits!(
 impl ToVariant for NodePath {
     fn to_variant(&self) -> Variant {
         Variant::from_node_path(self)
-    }
-}
-
-impl FromVariant for NodePath {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_node_path()
     }
 }
 

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -1,6 +1,5 @@
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 
@@ -200,12 +199,6 @@ impl_basic_traits!(
 impl ToVariant for GodotString {
     fn to_variant(&self) -> Variant {
         Variant::from_godot_string(self)
-    }
-}
-
-impl FromVariant for GodotString {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_godot_string()
     }
 }
 

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::GodotString;
 use crate::ToVariant;
 use crate::Variant;
@@ -131,12 +130,6 @@ impl_basic_traits!(
 impl ToVariant for StringArray {
     fn to_variant(&self) -> Variant {
         Variant::from_string_array(self)
-    }
-}
-
-impl FromVariant for StringArray {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_string_array()
     }
 }
 

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,6 +1,5 @@
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 
@@ -191,12 +190,6 @@ impl_basic_traits!(
 impl ToVariant for VariantArray {
     fn to_variant(&self) -> Variant {
         Variant::from_array(self)
-    }
-}
-
-impl FromVariant for VariantArray {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_array()
     }
 }
 

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -1,15 +1,9 @@
 use crate::{Angle, Rotation2D, Vector2};
-use crate::{FromVariant, ToVariant, Variant};
+use crate::{ToVariant, Variant};
 
 impl ToVariant for Vector2 {
     fn to_variant(&self) -> Variant {
         Variant::from_vector2(self)
-    }
-}
-
-impl FromVariant for Vector2 {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_vector2()
     }
 }
 
@@ -93,6 +87,7 @@ impl Vector2Godot for Vector2 {
 godot_test!(
     test_vector2_variants {
         fn test(vector: Vector2, set_to: Vector2) {
+            use crate::FromVariant;
             let api = crate::get_api();
 
             let copied = vector;

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -134,12 +133,6 @@ impl_basic_traits!(
 impl ToVariant for Vector2Array {
     fn to_variant(&self) -> Variant {
         Variant::from_vector2_array(self)
-    }
-}
-
-impl FromVariant for Vector2Array {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_vector2_array()
     }
 }
 

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -1,4 +1,3 @@
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::Vector3;
@@ -9,15 +8,11 @@ impl ToVariant for Vector3 {
     }
 }
 
-impl FromVariant for Vector3 {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_vector3()
-    }
-}
-
 godot_test!(
     test_vector3_variants {
         fn test(vector: Vector3, set_to: Vector3) {
+            use crate::FromVariant;
+
             let api = crate::get_api();
 
             let copied = vector;
@@ -65,7 +60,7 @@ godot_test!(
         test(Vector3::new(1.0, 2.0, 3.0), Vector3::new(4.0, 5.0, 6.0));
         test(Vector3::new(4.0, 5.0, 6.0), Vector3::new(7.0, 8.0, 9.0));
     }
-    );
+);
 
 #[cfg(test)]
 mod tests {

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -1,7 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::FromVariant;
 use crate::ToVariant;
 use crate::Variant;
 use crate::VariantArray;
@@ -134,12 +133,6 @@ impl_basic_traits!(
 impl ToVariant for Vector3Array {
     fn to_variant(&self) -> Variant {
         Variant::from_vector3_array(self)
-    }
-}
-
-impl FromVariant for Vector3Array {
-    fn from_variant(variant: &Variant) -> Option<Self> {
-        variant.try_to_vector3_array()
     }
 }
 

--- a/gdnative-derive/src/derive_macro.rs
+++ b/gdnative-derive/src/derive_macro.rs
@@ -30,7 +30,8 @@ pub(crate) fn parse_derive_input(input: TokenStream) -> DeriveData {
         .expect("No \"inherit\" attribute found");
 
     // read base class
-    let base = syn::parse::<Type>(inherit_attr.tokens.clone().into())
+    let base = inherit_attr
+        .parse_args::<Type>()
         .expect("`inherits` attribute requires the base type as an argument.");
 
     let register_callback = input
@@ -47,7 +48,7 @@ pub(crate) fn parse_derive_input(input: TokenStream) -> DeriveData {
         .iter()
         .find(|a| a.path.is_ident("user_data"))
         .map(|attr| {
-            syn::parse::<Type>(attr.tokens.clone().into())
+            attr.parse_args::<Type>()
                 .expect("`userdata` attribute requires a type as an argument.")
         })
         .unwrap_or_else(|| {

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -308,10 +308,10 @@ fn test_derive_to_variant() -> bool {
             .expect("should be dictionary");
         assert_eq!(Some(true), enum_dict.get(&"Foo".into()).try_to_bool());
         assert_eq!(
-            Some(&data.baz),
+            Ok(&data.baz),
             ToVarEnum::from_variant(&enum_dict.to_variant()).as_ref()
         );
-        assert_eq!(Some(&data), ToVar::from_variant(&variant).as_ref());
+        assert_eq!(Ok(&data), ToVar::from_variant(&variant).as_ref());
     })
     .is_ok();
 


### PR DESCRIPTION
Originally, `from_variant`'s return value only indicated whether the conversion was successful, without providing any information on the error. This was sufficient for primitive values, but produced rather unhelpful error messages when working with structures, for which `FromVariant` can now be derived using a proc-macro.
    
This PR changes the return value of `FromVariant::from_variant` to `Result`, and adds a new error enum that represent detailed information on how the conversion failed. This should greatly benefit development where passing complex arguments from GDScript to Rust is desired.

Example error message: `ERROR: <native>: Cannot convert argument #1 (options) to Options: invalid value for field thing.position.y: invalid variant type: expected I64, got F64 (non-primitive types may impose structural checks)`

## Compatibility

This is a breaking change on `FromVariant`. The minor version would have to be bumped for the next release.

Custom implementations and direct usage of `FromVariant` need to be changed. The changes should be relatively easy. Changes to examples were not needed.