### PR TITLE
Implement ToVariant for the rest of core types

### DIFF
--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -1,8 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 
 /// A reference-counted vector of bytes that uses Godot's pool allocator.
@@ -125,12 +123,6 @@ impl_basic_traits!(
         Default => godot_pool_byte_array_new;
     }
 );
-
-impl ToVariant for ByteArray {
-    fn to_variant(&self) -> Variant {
-        Variant::from_byte_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_byte_array_read_access {

--- a/gdnative-core/src/color.rs
+++ b/gdnative-core/src/color.rs
@@ -21,20 +21,21 @@ impl Color {
         Color { r, g, b, a: 1.0 }
     }
 
-    fn as_sys_color(&self) -> &sys::godot_color {
-        unsafe { transmute(self) }
-    }
-
     pub fn h(&self) -> f32 {
-        unsafe { (get_api().godot_color_get_h)(self.as_sys_color()) }
+        unsafe { (get_api().godot_color_get_h)(self.sys()) }
     }
 
     pub fn s(&self) -> f32 {
-        unsafe { (get_api().godot_color_get_s)(self.as_sys_color()) }
+        unsafe { (get_api().godot_color_get_s)(self.sys()) }
     }
 
     pub fn v(&self) -> f32 {
-        unsafe { (get_api().godot_color_get_v)(self.as_sys_color()) }
+        unsafe { (get_api().godot_color_get_v)(self.sys()) }
+    }
+
+    #[doc(hidden)]
+    pub fn sys(&self) -> &sys::godot_color {
+        unsafe { transmute(self) }
     }
 
     #[doc(hidden)]

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -2,8 +2,6 @@ use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
 use crate::Color;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 
 use std::mem::transmute;
@@ -129,12 +127,6 @@ impl_basic_traits!(
         Default => godot_pool_color_array_new;
     }
 );
-
-impl ToVariant for ColorArray {
-    fn to_variant(&self) -> Variant {
-        Variant::from_color_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_color_array_read_access {

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -1,7 +1,7 @@
 use crate::get_api;
 use crate::sys;
 use crate::GodotString;
-use crate::ToVariant;
+
 use crate::Variant;
 use crate::VariantArray;
 use std::fmt;
@@ -121,12 +121,6 @@ impl_basic_traits!(
         Eq => godot_dictionary_operator_equal;
     }
 );
-
-impl ToVariant for Dictionary {
-    fn to_variant(&self) -> Variant {
-        Variant::from_dictionary(self)
-    }
-}
 
 impl fmt::Debug for Dictionary {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -1,8 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 
 /// A reference-counted vector of `f32` that uses Godot's pool allocator.
@@ -125,12 +123,6 @@ impl_basic_traits!(
         Default => godot_pool_real_array_new;
     }
 );
-
-impl ToVariant for Float32Array {
-    fn to_variant(&self) -> Variant {
-        Variant::from_float32_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_real_array_read_access {

--- a/gdnative-core/src/geom/aabb.rs
+++ b/gdnative-core/src/geom/aabb.rs
@@ -10,6 +10,11 @@ pub struct Aabb {
 
 impl Aabb {
     #[doc(hidden)]
+    pub fn sys(&self) -> *const sys::godot_aabb {
+        unsafe { std::mem::transmute::<*const Aabb, *const sys::godot_aabb>(self as *const _) }
+    }
+
+    #[doc(hidden)]
     pub fn from_sys(c: sys::godot_aabb) -> Self {
         unsafe { std::mem::transmute::<sys::godot_aabb, Self>(c) }
     }

--- a/gdnative-core/src/geom/basis.rs
+++ b/gdnative-core/src/geom/basis.rs
@@ -9,6 +9,11 @@ pub struct Basis {
 
 impl Basis {
     #[doc(hidden)]
+    pub fn sys(&self) -> *const sys::godot_basis {
+        unsafe { std::mem::transmute::<*const Basis, *const sys::godot_basis>(self as *const _) }
+    }
+
+    #[doc(hidden)]
     pub fn from_sys(c: sys::godot_basis) -> Self {
         unsafe { std::mem::transmute::<sys::godot_basis, Self>(c) }
     }

--- a/gdnative-core/src/geom/plane.rs
+++ b/gdnative-core/src/geom/plane.rs
@@ -10,6 +10,11 @@ pub struct Plane {
 
 impl Plane {
     #[doc(hidden)]
+    pub fn sys(&self) -> *const sys::godot_plane {
+        unsafe { std::mem::transmute::<*const Plane, *const sys::godot_plane>(self as *const _) }
+    }
+
+    #[doc(hidden)]
     pub fn from_sys(c: sys::godot_plane) -> Self {
         unsafe { std::mem::transmute::<sys::godot_plane, Self>(c) }
     }

--- a/gdnative-core/src/geom/transform.rs
+++ b/gdnative-core/src/geom/transform.rs
@@ -14,6 +14,13 @@ pub struct Transform {
 
 impl Transform {
     #[doc(hidden)]
+    pub fn sys(&self) -> *const sys::godot_transform {
+        unsafe {
+            std::mem::transmute::<*const Transform, *const sys::godot_transform>(self as *const _)
+        }
+    }
+
+    #[doc(hidden)]
     pub fn from_sys(c: sys::godot_transform) -> Self {
         unsafe { std::mem::transmute::<sys::godot_transform, Self>(c) }
     }

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -27,7 +27,7 @@ use crate::FromVariant;
 use crate::Map;
 use crate::MapMut;
 use crate::NativeClass;
-use crate::ToVariant;
+
 use crate::Variant;
 use libc;
 use std::ffi::CString;

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -1,8 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 
 /// A reference-counted vector of `i32` that uses Godot's pool allocator.
@@ -125,12 +123,6 @@ impl_basic_traits!(
         Default => godot_pool_int_array_new;
     }
 );
-
-impl ToVariant for Int32Array {
-    fn to_variant(&self) -> Variant {
-        Variant::from_int32_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_int_array_read_access {

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -1,8 +1,6 @@
 use crate::get_api;
 use crate::sys;
 use crate::GodotString;
-use crate::ToVariant;
-use crate::Variant;
 use std::fmt;
 
 /// A reference-counted relative or absolute path in a scene tree, for use with `Node.get_node()` and similar
@@ -143,12 +141,6 @@ impl_basic_traits!(
         Eq => godot_node_path_operator_equal;
     }
 );
-
-impl ToVariant for NodePath {
-    fn to_variant(&self) -> Variant {
-        Variant::from_node_path(self)
-    }
-}
 
 impl fmt::Debug for NodePath {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -1,7 +1,5 @@
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 
 use std::cmp::Ordering;
 use std::ffi::CStr;
@@ -196,12 +194,6 @@ impl_basic_traits!(
     }
 );
 
-impl ToVariant for GodotString {
-    fn to_variant(&self) -> Variant {
-        Variant::from_godot_string(self)
-    }
-}
-
 impl fmt::Debug for GodotString {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.to_string().fmt(f)
@@ -339,7 +331,8 @@ where
 }
 
 godot_test!(test_string {
-    use crate::VariantType;
+    use crate::{GodotString, Variant, VariantType};
+
     let foo: GodotString = "foo".into();
     assert_eq!(foo.len(), 3);
 

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -2,8 +2,6 @@ use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
 use crate::GodotString;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 
 /// A vector of `GodotString` that uses Godot's pool allocator.
@@ -126,12 +124,6 @@ impl_basic_traits!(
         Default => godot_pool_string_array_new;
     }
 );
-
-impl ToVariant for StringArray {
-    fn to_variant(&self) -> Variant {
-        Variant::from_string_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_string_array_read_access {

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -11,44 +11,17 @@ use std::mem::{forget, transmute};
 /// dependning on the size of the type and whether the it is trivially copyable.
 pub struct Variant(pub(crate) sys::godot_variant);
 
-macro_rules! variant_constructors_transmute {
+macro_rules! variant_constructors {
     (
         $(
             $(#[$attr:meta])*
-            pub fn $ctor:ident($Type:ty) -> Self as $GdType:ty : $gd_method:ident;
+            pub fn $ctor:ident($Type:ty) -> Self;
         )*
     ) => (
         $(
             $(#[$attr])*
             pub fn $ctor(val: $Type) -> Variant {
-                unsafe {
-                    let api = get_api();
-                    let mut dest = sys::godot_variant::default();
-                    let gd_val: $GdType = transmute(*val);
-                    (api.$gd_method)(&mut dest, &gd_val);
-                    Variant(dest)
-                }
-            }
-        )*
-    )
-}
-
-macro_rules! variant_constructors_wrap {
-    (
-        $(
-            $(#[$attr:meta])*
-            pub fn $ctor:ident($Type:ty) -> Self as $GdType:ty : $gd_method:ident;
-        )*
-    ) => (
-        $(
-            $(#[$attr])*
-            pub fn $ctor(val: $Type) -> Variant {
-                unsafe {
-                    let api = get_api();
-                    let mut dest = sys::godot_variant::default();
-                    (api.$gd_method)(&mut dest, &val.0);
-                    Variant(dest)
-                }
+                ToVariant::to_variant(val)
             }
         )*
     )
@@ -223,54 +196,51 @@ type I64 = i64;
 type Bool = bool;
 
 impl Variant {
-    variant_constructors_transmute!(
+    variant_constructors!(
         /// Creates a `Variant` wrapping a `Vector2`.
-        pub fn from_vector2(&Vector2) -> Self as sys::godot_vector2 : godot_variant_new_vector2;
+        pub fn from_vector2(&Vector2) -> Self;
         /// Creates a `Variant` wrapping a `Vector3`.
-        pub fn from_vector3(&Vector3) -> Self as sys::godot_vector3 : godot_variant_new_vector3;
+        pub fn from_vector3(&Vector3) -> Self;
         /// Creates a `Variant` wrapping a `Quat`.
-        pub fn from_quat(&Quat) -> Self as sys::godot_quat : godot_variant_new_quat;
+        pub fn from_quat(&Quat) -> Self;
         /// Creates a `Variant` wrapping a `Plane`.
-        pub fn from_plane(&Plane) -> Self as sys::godot_plane : godot_variant_new_plane;
+        pub fn from_plane(&Plane) -> Self;
         /// Creates a `Variant` wrapping a `Rect2`.
-        pub fn from_rect2(&Rect2) -> Self as sys::godot_rect2 : godot_variant_new_rect2;
+        pub fn from_rect2(&Rect2) -> Self;
         /// Creates a `Variant` wrapping a `Transform`.
-        pub fn from_transform(&Transform) -> Self as sys::godot_transform : godot_variant_new_transform;
+        pub fn from_transform(&Transform) -> Self;
         /// Creates a `Variant` wrapping a `Transform2D`.
-        pub fn from_transform2d(&Transform2D) -> Self as sys::godot_transform2d : godot_variant_new_transform2d;
+        pub fn from_transform2d(&Transform2D) -> Self;
         /// Creates a `Variant` wrapping a `Basis`.
-        pub fn from_basis(&Basis) -> Self as sys::godot_basis : godot_variant_new_basis;
+        pub fn from_basis(&Basis) -> Self;
         /// Creates a `Variant` wrapping a `Color`.
-        pub fn from_color(&Color) -> Self as sys::godot_color : godot_variant_new_color;
+        pub fn from_color(&Color) -> Self;
         /// Creates a `Variant` wrapping an `Aabb`.
-        pub fn from_aabb(&Aabb) -> Self as sys::godot_aabb : godot_variant_new_aabb;
-    );
-
-    variant_constructors_wrap!(
+        pub fn from_aabb(&Aabb) -> Self;
         /// Creates a `Variant` wrapping an `Rid`.
-        pub fn from_rid(&Rid) -> Self as sys::godot_rid : godot_variant_new_rid;
+        pub fn from_rid(&Rid) -> Self;
         /// Creates a `Variant` wrapping a `NodePath`.
-        pub fn from_node_path(&NodePath) -> Self as sys::godot_node_path : godot_variant_new_node_path;
+        pub fn from_node_path(&NodePath) -> Self;
         /// Creates a `Variant` wrapping a `GodotString`.
-        pub fn from_godot_string(&GodotString) -> Self as sys::godot_string : godot_variant_new_string;
+        pub fn from_godot_string(&GodotString) -> Self;
         /// Creates an `Variant` wrapping an array of variants.
-        pub fn from_array(&VariantArray) -> Self as sys::godot_array : godot_variant_new_array;
+        pub fn from_array(&VariantArray) -> Self;
         /// Creates a `Variant` wrapping a byte array.
-        pub fn from_byte_array(&ByteArray) -> Self as sys::godot_pool_byte_array : godot_variant_new_pool_byte_array;
+        pub fn from_byte_array(&ByteArray) -> Self;
         /// Creates a `Variant` wrapping an array of 32bit signed integers.
-        pub fn from_int32_array(&Int32Array) -> Self as sys::godot_pool_int_array : godot_variant_new_pool_int_array;
+        pub fn from_int32_array(&Int32Array) -> Self;
         /// Creates a `Variant` wrapping an array of 32bit floats.
-        pub fn from_float32_array(&Float32Array) -> Self as sys::godot_pool_real_array : godot_variant_new_pool_real_array;
+        pub fn from_float32_array(&Float32Array) -> Self;
         /// Creates a `Variant` wrapping an array of godot strings.
-        pub fn from_string_array(&StringArray) -> Self as sys::godot_pool_string_array : godot_variant_new_pool_string_array;
+        pub fn from_string_array(&StringArray) -> Self;
         /// Creates a `Variant` wrapping an array of 2d vectors.
-        pub fn from_vector2_array(&Vector2Array) -> Self as sys::godot_pool_vector2_array : godot_variant_new_pool_vector2_array;
+        pub fn from_vector2_array(&Vector2Array) -> Self;
         /// Creates a `Variant` wrapping an array of 3d vectors.
-        pub fn from_vector3_array(&Vector3Array) -> Self as sys::godot_pool_vector3_array : godot_variant_new_pool_vector3_array;
+        pub fn from_vector3_array(&Vector3Array) -> Self;
         /// Creates a `Variant` wrapping an array of colors.
-        pub fn from_color_array(&ColorArray) -> Self as sys::godot_pool_color_array : godot_variant_new_pool_color_array;
+        pub fn from_color_array(&ColorArray) -> Self;
         /// Creates a `Variant` wrapping a dictionary.
-        pub fn from_dictionary(&Dictionary) -> Self as sys::godot_dictionary : godot_variant_new_dictionary;
+        pub fn from_dictionary(&Dictionary) -> Self;
     );
 
     /// Creates an empty `Variant`.
@@ -1109,6 +1079,72 @@ impl_to_variant_for_num!(
     usize: u64
     f32: f64
 );
+
+macro_rules! to_variant_transmute {
+    (
+        $(impl ToVariant for $ty:ident: $ctor:ident;)*
+    ) => {
+        $(
+            impl ToVariant for $ty {
+                fn to_variant(&self) -> Variant {
+                    unsafe {
+                        let api = get_api();
+                        let mut dest = sys::godot_variant::default();
+                        (api.$ctor)(&mut dest, transmute(self));
+                        Variant::from_sys(dest)
+                    }
+                }
+            }
+        )*
+    }
+}
+
+to_variant_transmute! {
+    impl ToVariant for Vector2 : godot_variant_new_vector2;
+    impl ToVariant for Vector3 : godot_variant_new_vector3;
+    impl ToVariant for Quat : godot_variant_new_quat;
+    impl ToVariant for Rect2 : godot_variant_new_rect2;
+    impl ToVariant for Transform2D : godot_variant_new_transform2d;
+}
+
+macro_rules! to_variant_as_sys {
+    (
+        $(impl ToVariant for $ty:ident: $ctor:ident;)*
+    ) => {
+        $(
+            impl ToVariant for $ty {
+                fn to_variant(&self) -> Variant {
+                    unsafe {
+                        let api = get_api();
+                        let mut dest = sys::godot_variant::default();
+                        (api.$ctor)(&mut dest, self.sys());
+                        Variant::from_sys(dest)
+                    }
+                }
+            }
+        )*
+    }
+}
+
+to_variant_as_sys! {
+    impl ToVariant for Plane : godot_variant_new_plane;
+    impl ToVariant for Transform : godot_variant_new_transform;
+    impl ToVariant for Basis : godot_variant_new_basis;
+    impl ToVariant for Color : godot_variant_new_color;
+    impl ToVariant for Aabb : godot_variant_new_aabb;
+    impl ToVariant for Rid : godot_variant_new_rid;
+    impl ToVariant for NodePath : godot_variant_new_node_path;
+    impl ToVariant for GodotString : godot_variant_new_string;
+    impl ToVariant for VariantArray : godot_variant_new_array;
+    impl ToVariant for ByteArray : godot_variant_new_pool_byte_array;
+    impl ToVariant for Int32Array : godot_variant_new_pool_int_array;
+    impl ToVariant for Float32Array : godot_variant_new_pool_real_array;
+    impl ToVariant for StringArray : godot_variant_new_pool_string_array;
+    impl ToVariant for Vector2Array : godot_variant_new_pool_vector2_array;
+    impl ToVariant for Vector3Array : godot_variant_new_pool_vector3_array;
+    impl ToVariant for ColorArray : godot_variant_new_pool_color_array;
+    impl ToVariant for Dictionary : godot_variant_new_dictionary;
+}
 
 macro_rules! from_variant_transmute {
     (

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,6 +1,6 @@
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
+
 use crate::Variant;
 
 /// A reference-counted `Variant` vector. Godot's generic array data type.
@@ -186,12 +186,6 @@ impl_basic_traits!(
         Default => godot_array_new;
     }
 );
-
-impl ToVariant for VariantArray {
-    fn to_variant(&self) -> Variant {
-        Variant::from_array(self)
-    }
-}
 
 pub struct Iter<'a> {
     arr: &'a VariantArray,

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -1,11 +1,4 @@
 use crate::{Angle, Rotation2D, Vector2};
-use crate::{ToVariant, Variant};
-
-impl ToVariant for Vector2 {
-    fn to_variant(&self) -> Variant {
-        Variant::from_vector2(self)
-    }
-}
 
 /// Helper methods for `Vector2`.
 ///
@@ -86,6 +79,8 @@ impl Vector2Godot for Vector2 {
 
 godot_test!(
     test_vector2_variants {
+        use crate::ToVariant;
+
         fn test(vector: Vector2, set_to: Vector2) {
             use crate::FromVariant;
             let api = crate::get_api();

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -1,8 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 use crate::Vector2;
 
@@ -129,12 +127,6 @@ impl_basic_traits!(
         Default => godot_pool_vector2_array_new;
     }
 );
-
-impl ToVariant for Vector2Array {
-    fn to_variant(&self) -> Variant {
-        Variant::from_vector2_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_vector2_array_read_access {

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -1,18 +1,8 @@
-use crate::ToVariant;
-use crate::Variant;
-use crate::Vector3;
-
-impl ToVariant for Vector3 {
-    fn to_variant(&self) -> Variant {
-        Variant::from_vector3(self)
-    }
-}
-
 godot_test!(
     test_vector3_variants {
-        fn test(vector: Vector3, set_to: Vector3) {
-            use crate::FromVariant;
+        use crate::{FromVariant, ToVariant, Vector3};
 
+        fn test(vector: Vector3, set_to: Vector3) {
             let api = crate::get_api();
 
             let copied = vector;
@@ -64,7 +54,7 @@ godot_test!(
 
 #[cfg(test)]
 mod tests {
-    use super::Vector3;
+    use crate::Vector3;
 
     #[test]
     fn it_is_copy() {

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -1,8 +1,6 @@
 use crate::access::{Aligned, MaybeUnaligned};
 use crate::get_api;
 use crate::sys;
-use crate::ToVariant;
-use crate::Variant;
 use crate::VariantArray;
 use crate::Vector3;
 
@@ -129,12 +127,6 @@ impl_basic_traits!(
         Default => godot_pool_vector3_array_new;
     }
 );
-
-impl ToVariant for Vector3Array {
-    fn to_variant(&self) -> Variant {
-        Variant::from_vector3_array(self)
-    }
-}
 
 define_access_guard! {
     pub struct ReadGuard<'a> : sys::godot_pool_vector3_array_read_access {


### PR DESCRIPTION
As it turned out, there are still a few core types that don't implement `ToVariant` yet. This PR added implementations for all of them.