### PR TITLE
Redesign Property API, implementing all hints, and making default value optional

### DIFF
--- a/examples/signals/src/lib.rs
+++ b/examples/signals/src/lib.rs
@@ -23,7 +23,7 @@ impl SignalEmitter {
             args: &[init::SignalArgument {
                 name: "data",
                 default: Variant::from_i64(100),
-                hint: init::PropertyHint::None,
+                export_info: init::ExportInfo::new(VariantType::I64),
                 usage: init::PropertyUsage::DEFAULT,
             }],
         });

--- a/examples/spinning_cube/Main.tscn
+++ b/examples/spinning_cube/Main.tscn
@@ -19,10 +19,7 @@ mesh = SubResource( 1 )
 material/0 = SubResource( 2 )
 script = SubResource( 3 )
 base/rotate_speed = 1.0
-test/test_enum = null
-test/test_flags = null
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 0.572229, -0.327396, 0.751909, 0, 0.916856, 0.399217, -0.820094, -0.228443, 0.524651, 4.71648, 2.5, 3.45846 )
 current = true
-

--- a/examples/spinning_cube/default_env.tres
+++ b/examples/spinning_cube/default_env.tres
@@ -12,4 +12,3 @@ sun_energy = 16.0
 [resource]
 background_mode = 2
 background_sky = SubResource( 1 )
-

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -1,52 +1,54 @@
 #[macro_use]
-extern crate gdnative as godot;
+extern crate gdnative;
 
-#[derive(godot::NativeClass)]
-#[inherit(godot::MeshInstance)]
-#[user_data(godot::user_data::MutexData<RustTest>)]
+use gdnative::init::property::{EnumHint, IntHint, StringHint};
+
+#[derive(gdnative::NativeClass)]
+#[inherit(gdnative::MeshInstance)]
+#[user_data(gdnative::user_data::MutexData<RustTest>)]
 #[register_with(my_register_function)]
 struct RustTest {
-    start: godot::Vector3,
+    start: gdnative::Vector3,
     time: f32,
-    #[property(default = 0.05)]
+    #[property(path = "base/rotate_speed")]
     rotate_speed: f64,
 }
 
-fn my_register_function(builder: &godot::init::ClassBuilder<RustTest>) {
-    builder.add_property(godot::init::Property {
-        name: "test/test_enum",
-        default: godot::GodotString::from_str("Hello"),
-        hint: godot::init::PropertyHint::Enum {
-            values: &["Hello", "World", "Testing"],
-        },
-        getter: |_: &RustTest| godot::GodotString::from_str("Hello"),
-        setter: (),
-        usage: godot::init::PropertyUsage::DEFAULT,
-    });
-    builder.add_property(godot::init::Property {
-        name: "test/test_flags",
-        default: 0,
-        hint: godot::init::PropertyHint::Flags {
-            values: &["A", "B", "C", "D"],
-        },
-        getter: |_: &RustTest| 0,
-        setter: (),
-        usage: godot::init::PropertyUsage::DEFAULT,
-    });
+fn my_register_function(builder: &gdnative::init::ClassBuilder<RustTest>) {
+    builder
+        .add_property::<String>("test/test_enum")
+        .with_hint(StringHint::Enum(EnumHint::new(vec![
+            "Hello".into(),
+            "World".into(),
+            "Testing".into(),
+        ])))
+        .with_getter(|_: &RustTest, _| "Hello".to_string())
+        .done();
+
+    builder
+        .add_property("test/test_flags")
+        .with_hint(IntHint::Flags(EnumHint::new(vec![
+            "A".into(),
+            "B".into(),
+            "C".into(),
+            "D".into(),
+        ])))
+        .with_getter(|_: &RustTest, _| 0)
+        .done();
 }
 
-#[godot::methods]
+#[gdnative::methods]
 impl RustTest {
-    fn _init(_owner: godot::MeshInstance) -> Self {
+    fn _init(_owner: gdnative::MeshInstance) -> Self {
         RustTest {
-            start: godot::Vector3::new(0.0, 0.0, 0.0),
+            start: gdnative::Vector3::new(0.0, 0.0, 0.0),
             time: 0.0,
             rotate_speed: 0.05,
         }
     }
 
     #[export]
-    unsafe fn _ready(&mut self, mut owner: godot::MeshInstance) {
+    unsafe fn _ready(&mut self, mut owner: gdnative::MeshInstance) {
         owner.set_physics_process(true);
         self.start = owner.get_translation();
         godot_warn!("Start: {:?}", self.start);
@@ -57,8 +59,8 @@ impl RustTest {
     }
 
     #[export]
-    unsafe fn _physics_process(&mut self, mut owner: godot::MeshInstance, delta: f64) {
-        use godot::{Color, SpatialMaterial, Vector3};
+    unsafe fn _physics_process(&mut self, mut owner: gdnative::MeshInstance, delta: f64) {
+        use gdnative::{Color, SpatialMaterial, Vector3};
 
         self.time += delta as f32;
         owner.rotate_y(self.rotate_speed * delta);
@@ -73,7 +75,7 @@ impl RustTest {
     }
 }
 
-fn init(handle: godot::init::InitHandle) {
+fn init(handle: gdnative::init::InitHandle) {
     handle.add_class::<RustTest>();
 }
 

--- a/gdnative-core/src/init/property.rs
+++ b/gdnative-core/src/init/property.rs
@@ -1,0 +1,444 @@
+//! Property registration.
+
+use std::mem;
+
+use crate::get_api;
+use crate::object::GodotObject;
+use crate::GodotString;
+use crate::NativeClass;
+use crate::ToVariant;
+use crate::VariantType;
+
+use super::ClassBuilder;
+
+mod accessor;
+pub mod hint;
+
+pub use hint::*;
+
+use accessor::{Getter, InvalidGetter, InvalidSetter, RawGetter, RawSetter, Setter};
+
+/// Trait for exportable types.
+pub trait Export: ToVariant {
+    /// A type-specific hint type that is valid for the type being exported.
+    type Hint;
+
+    /// Returns `ExportInfo` given an optional typed hint.
+    fn export_info(hint: Option<Self::Hint>) -> ExportInfo;
+}
+
+/// Metadata about the exported property.
+#[derive(Debug)]
+pub struct ExportInfo {
+    pub variant_type: VariantType,
+    pub hint_kind: sys::godot_property_hint,
+    pub hint_string: GodotString,
+}
+
+impl ExportInfo {
+    /// Create an `ExportInfo` with the given Variant type, but without a hint.
+    pub fn new(variant_type: VariantType) -> Self {
+        ExportInfo {
+            variant_type,
+            hint_kind: sys::godot_property_hint_GODOT_PROPERTY_HINT_NONE,
+            hint_string: GodotString::new(),
+        }
+    }
+
+    /// Create an `ExportInfo` with a hint for a specific Godot resource type.
+    pub fn resource_type<T>() -> Self
+    where
+        T: GodotObject,
+    {
+        ExportInfo {
+            variant_type: VariantType::Object,
+            hint_kind: sys::godot_property_hint_GODOT_PROPERTY_HINT_RESOURCE_TYPE,
+            hint_string: T::class_name().into(),
+        }
+    }
+}
+
+/// Builder type used to register a property on a `NativeClass`.
+#[derive(Debug)]
+#[must_use]
+pub struct PropertyBuilder<'a, C, T: Export, S = InvalidSetter<'a>, G = InvalidGetter<'a>> {
+    name: &'a str,
+    setter: S,
+    getter: G,
+    default: Option<T>,
+    hint: Option<T::Hint>,
+    usage: Usage,
+    class_builder: &'a ClassBuilder<C>,
+}
+
+impl<'a, C, T> PropertyBuilder<'a, C, T, InvalidSetter<'a>, InvalidGetter<'a>>
+where
+    C: NativeClass,
+    T: Export,
+{
+    /// Creates a new `PropertyBuilder` with the given property name.
+    pub(super) fn new(class_builder: &'a ClassBuilder<C>, name: &'a str) -> Self {
+        PropertyBuilder {
+            name,
+            setter: InvalidSetter::new(name),
+            getter: InvalidGetter::new(name),
+            default: None,
+            hint: None,
+            usage: Usage::DEFAULT,
+            class_builder,
+        }
+    }
+}
+
+impl<'a, C, T, S, G> PropertyBuilder<'a, C, T, S, G>
+where
+    C: NativeClass,
+    T: Export,
+    S: RawSetter<C, T>,
+    G: RawGetter<C, T>,
+{
+    /// Register the property built with this builder.
+    pub fn done(self) {
+        let ExportInfo {
+            variant_type,
+            hint_kind,
+            hint_string,
+        } = T::export_info(self.hint);
+        let default = self.default.to_variant();
+
+        let mut attr = sys::godot_property_attributes {
+            rset_type: sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED, // TODO:
+            type_: variant_type as sys::godot_int,
+            hint: hint_kind,
+            hint_string: hint_string.to_sys(),
+            usage: self.usage.to_sys(),
+            default_value: default.to_sys(),
+        };
+
+        let path = ::std::ffi::CString::new(self.name).unwrap();
+
+        let set = unsafe { self.setter.as_godot_function() };
+        let get = unsafe { self.getter.as_godot_function() };
+
+        unsafe {
+            (get_api().godot_nativescript_register_property)(
+                self.class_builder.init_handle,
+                self.class_builder.class_name.as_ptr(),
+                path.as_ptr() as *const _,
+                &mut attr,
+                set,
+                get,
+            );
+        }
+    }
+
+    /// Provides a setter function with the signature `fn(&mut C, owner: C::Base, value: T)`
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_setter<NS>(
+        self,
+        setter: NS,
+    ) -> PropertyBuilder<'a, C, T, Setter<accessor::Mut, NS>, G>
+    where
+        Setter<accessor::Mut, NS>: RawSetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: Setter::new(setter),
+            getter: self.getter,
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Provides a setter function with the signature `fn(&C, owner: C::Base, value: T)`
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_shr_setter<NS>(
+        self,
+        setter: NS,
+    ) -> PropertyBuilder<'a, C, T, Setter<accessor::Shr, NS>, G>
+    where
+        Setter<accessor::Shr, NS>: RawSetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: Setter::new(setter),
+            getter: self.getter,
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Provides a getter function with the signature `fn(&C, owner: C::Base) -> T`,
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_getter<NG>(
+        self,
+        getter: NG,
+    ) -> PropertyBuilder<'a, C, T, S, Getter<accessor::Shr, accessor::Owned, NG>>
+    where
+        Getter<accessor::Shr, accessor::Owned, NG>: RawGetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: self.setter,
+            getter: Getter::new(getter),
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Provides a getter function with the signature `fn(&C, owner: C::Base) -> &T`,
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_ref_getter<NG>(
+        self,
+        getter: NG,
+    ) -> PropertyBuilder<'a, C, T, S, Getter<accessor::Shr, accessor::Ref, NG>>
+    where
+        Getter<accessor::Shr, accessor::Ref, NG>: RawGetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: self.setter,
+            getter: Getter::new(getter),
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Provides a getter function with the signature `fn(&mut C, owner: C::Base) -> T`,
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_mut_getter<NG>(
+        self,
+        getter: NG,
+    ) -> PropertyBuilder<'a, C, T, S, Getter<accessor::Mut, accessor::Owned, NG>>
+    where
+        Getter<accessor::Mut, accessor::Owned, NG>: RawGetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: self.setter,
+            getter: Getter::new(getter),
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Provides a getter function with the signature `fn(&mut C, owner: C::Base) -> &T`,
+    /// where `C` is the `NativeClass` type being registered and `T` is the type of the property.
+    pub fn with_mut_ref_getter<NG>(
+        self,
+        getter: NG,
+    ) -> PropertyBuilder<'a, C, T, S, Getter<accessor::Mut, accessor::Ref, NG>>
+    where
+        Getter<accessor::Mut, accessor::Ref, NG>: RawGetter<C, T>,
+    {
+        PropertyBuilder {
+            name: self.name,
+            setter: self.setter,
+            getter: Getter::new(getter),
+            default: self.default,
+            hint: self.hint,
+            usage: self.usage,
+            class_builder: self.class_builder,
+        }
+    }
+
+    /// Sets a default value for the property as a hint to the editor. The setter may or may not
+    /// be actually called with this value.
+    pub fn with_default(mut self, default: T) -> Self {
+        self.default = Some(default);
+        self
+    }
+
+    /// Sets an editor hint.
+    pub fn with_hint(mut self, hint: T::Hint) -> Self {
+        self.hint = Some(hint);
+        self
+    }
+
+    /// Sets a property usage.
+    pub fn with_usage(mut self, usage: Usage) -> Self {
+        self.usage = usage;
+        self
+    }
+}
+
+bitflags! {
+    pub struct Usage: u32 {
+        const STORAGE = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_STORAGE as u32;
+        const EDITOR = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_EDITOR as u32;
+        const NETWORK = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_NETWORK as u32;
+        const EDITOR_HELPER = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_EDITOR_HELPER as u32;
+        const CHECKABLE = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_CHECKABLE as u32;
+        const CHECKED = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_CHECKED as u32;
+        const INTERNATIONALIZED = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_INTERNATIONALIZED as u32;
+        const GROUP = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_GROUP as u32;
+        const CATEGORY = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_CATEGORY as u32;
+        const STORE_IF_NONZERO = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_STORE_IF_NONZERO as u32;
+        const STORE_IF_NONONE = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_STORE_IF_NONONE as u32;
+        const NO_INSTANCE_STATE = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_NO_INSTANCE_STATE as u32;
+        const RESTART_IF_CHANGED = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_RESTART_IF_CHANGED as u32;
+        const SCRIPT_VARIABLE  = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_SCRIPT_VARIABLE as u32;
+        const STORE_IF_NULL = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_STORE_IF_NULL as u32;
+        const ANIMATE_AS_TRIGGER = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_ANIMATE_AS_TRIGGER as u32;
+        const UPDATE_ALL_IF_MODIFIED = sys::godot_property_usage_flags_GODOT_PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED as u32;
+
+        const DEFAULT = Self::STORAGE.bits | Self::EDITOR.bits | Self::NETWORK.bits as u32;
+        const DEFAULT_INTL = Self::DEFAULT.bits | Self::INTERNATIONALIZED.bits as u32;
+        const NOEDITOR = Self::STORAGE.bits | Self::NETWORK.bits as u32;
+    }
+}
+
+impl Usage {
+    pub fn to_sys(&self) -> sys::godot_property_usage_flags {
+        unsafe { mem::transmute(*self) }
+    }
+}
+
+mod impl_export {
+    use super::*;
+    use crate::*;
+
+    macro_rules! impl_export_for_int {
+        ($ty:ident) => {
+            impl Export for $ty {
+                type Hint = hint::IntHint<$ty>;
+                fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+                    hint.map_or_else(
+                        || ExportInfo::new(VariantType::I64),
+                        Self::Hint::export_info,
+                    )
+                }
+            }
+        };
+    }
+
+    impl_export_for_int!(i8);
+    impl_export_for_int!(i16);
+    impl_export_for_int!(i32);
+    impl_export_for_int!(i64);
+    impl_export_for_int!(u8);
+    impl_export_for_int!(u16);
+    impl_export_for_int!(u32);
+    impl_export_for_int!(u64);
+
+    macro_rules! impl_export_for_float {
+        ($ty:ident) => {
+            impl Export for $ty {
+                type Hint = hint::FloatHint<$ty>;
+                fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+                    hint.map_or_else(
+                        || ExportInfo::new(VariantType::F64),
+                        Self::Hint::export_info,
+                    )
+                }
+            }
+        };
+    }
+
+    impl_export_for_float!(f32);
+    impl_export_for_float!(f64);
+
+    macro_rules! impl_export_for_string {
+        ($ty:ty) => {
+            impl Export for $ty {
+                type Hint = hint::StringHint;
+                fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+                    hint.map_or_else(
+                        || ExportInfo::new(VariantType::GodotString),
+                        Self::Hint::export_info,
+                    )
+                }
+            }
+        };
+    }
+
+    impl_export_for_string!(GodotString);
+    impl_export_for_string!(String);
+
+    macro_rules! impl_export_for_core_type_without_hint {
+        ($ty:ty: $variant_ty:ident) => {
+            impl Export for $ty {
+                type Hint = ();
+                fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
+                    ExportInfo::new(VariantType::$variant_ty)
+                }
+            }
+        };
+        ($ty:ident) => {
+            impl_export_for_core_type_without_hint!($ty: $ty);
+        };
+    }
+
+    impl_export_for_core_type_without_hint!(bool: Bool);
+    impl_export_for_core_type_without_hint!(Vector2);
+    impl_export_for_core_type_without_hint!(Rect2);
+    impl_export_for_core_type_without_hint!(Vector3);
+    impl_export_for_core_type_without_hint!(Transform2D);
+    impl_export_for_core_type_without_hint!(Plane);
+    impl_export_for_core_type_without_hint!(Quat);
+    impl_export_for_core_type_without_hint!(Aabb);
+    impl_export_for_core_type_without_hint!(Basis);
+    impl_export_for_core_type_without_hint!(Transform);
+    impl_export_for_core_type_without_hint!(NodePath);
+    impl_export_for_core_type_without_hint!(Rid);
+    impl_export_for_core_type_without_hint!(Dictionary);
+    impl_export_for_core_type_without_hint!(VariantArray);
+    impl_export_for_core_type_without_hint!(ByteArray);
+    impl_export_for_core_type_without_hint!(Int32Array);
+    impl_export_for_core_type_without_hint!(Float32Array);
+    impl_export_for_core_type_without_hint!(StringArray);
+    impl_export_for_core_type_without_hint!(Vector2Array);
+    impl_export_for_core_type_without_hint!(Vector3Array);
+    impl_export_for_core_type_without_hint!(ColorArray);
+
+    impl Export for Color {
+        type Hint = hint::ColorHint;
+        fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+            hint.map_or_else(
+                || ExportInfo::new(VariantType::Color),
+                Self::Hint::export_info,
+            )
+        }
+    }
+
+    impl<T> Export for T
+    where
+        T: GodotObject + ToVariant,
+    {
+        type Hint = ();
+        fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
+            ExportInfo::resource_type::<T>()
+        }
+    }
+
+    impl<T> Export for Instance<T>
+    where
+        T: NativeClass,
+        T::Base: ToVariant,
+    {
+        type Hint = ();
+        fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
+            ExportInfo::resource_type::<T::Base>()
+        }
+    }
+
+    impl<T> Export for Option<T>
+    where
+        T: Export,
+    {
+        type Hint = T::Hint;
+        fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+            T::export_info(hint)
+        }
+    }
+}

--- a/gdnative-core/src/init/property/accessor.rs
+++ b/gdnative-core/src/init/property/accessor.rs
@@ -1,0 +1,261 @@
+//! Types and traits for property accessors.
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use libc;
+
+use crate::object::GodotObject;
+use crate::user_data::UserData;
+use crate::FromVariant;
+use crate::Map;
+use crate::MapMut;
+use crate::NativeClass;
+use crate::ToVariant;
+use crate::Variant;
+
+mod invalid;
+
+pub use self::invalid::{InvalidGetter, InvalidSetter};
+
+/// Trait for raw property setters.
+///
+/// It's usually unnecessary to use this directly.
+pub unsafe trait RawSetter<C, T> {
+    unsafe fn as_godot_function(self) -> sys::godot_property_set_func;
+}
+
+/// Trait for raw property getters.
+///
+/// It's usually unnecessary to use this directly.
+pub unsafe trait RawGetter<C, T> {
+    unsafe fn as_godot_function(self) -> sys::godot_property_get_func;
+}
+
+#[derive(Debug)]
+pub struct Setter<SelfArg, F> {
+    func: F,
+    _self_arg: PhantomData<SelfArg>,
+}
+
+impl<SelfArg, F> Setter<SelfArg, F> {
+    pub fn new(func: F) -> Self {
+        Setter {
+            func,
+            _self_arg: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Getter<SelfArg, RetKind, F> {
+    func: F,
+    _self_arg: PhantomData<SelfArg>,
+    _ret_kind: PhantomData<RetKind>,
+}
+
+impl<SelfArg, RetKind, F> Getter<SelfArg, RetKind, F> {
+    pub fn new(func: F) -> Self {
+        Getter {
+            func,
+            _self_arg: PhantomData,
+            _ret_kind: PhantomData,
+        }
+    }
+}
+
+/// Marker type for accessors that take `&self` as their first arguments.
+pub struct Shr;
+/// Marker type for accessors that take `&mut self` as their first arguments.
+pub struct Mut;
+
+/// Helper trait for setters, generic over `self` argument mutability.
+pub trait MapSet<C: NativeClass, F, T> {
+    type Err: Debug;
+    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err>;
+}
+
+impl<C, F, T> MapSet<C, F, T> for Shr
+where
+    C: NativeClass,
+    C::UserData: Map,
+    F: 'static + Fn(&C, C::Base, T),
+{
+    type Err = <C::UserData as Map>::Err;
+    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err> {
+        user_data.map(|rust_ty| op(rust_ty, owner, value))
+    }
+}
+
+impl<C, F, T> MapSet<C, F, T> for Mut
+where
+    C: NativeClass,
+    C::UserData: MapMut,
+    F: 'static + Fn(&mut C, C::Base, T),
+{
+    type Err = <C::UserData as MapMut>::Err;
+    fn map_set(user_data: &C::UserData, op: &F, owner: C::Base, value: T) -> Result<(), Self::Err> {
+        user_data.map_mut(|rust_ty| op(rust_ty, owner, value))
+    }
+}
+
+/// Marker type for getters that return owned values.
+pub struct Owned;
+/// Marker type for getters that return references.
+pub struct Ref;
+
+/// Helper trait for setters, generic over `self` argument mutability and return kind.
+pub trait MapGet<C: NativeClass, F, T> {
+    type Err: Debug;
+    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err>;
+}
+
+impl<C, F, T> MapGet<C, F, T> for (Shr, Owned)
+where
+    C: NativeClass,
+    C::UserData: Map,
+    T: ToVariant,
+    F: 'static + Fn(&C, C::Base) -> T,
+{
+    type Err = <C::UserData as Map>::Err;
+    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+        user_data.map(|rust_ty| op(rust_ty, owner).to_variant())
+    }
+}
+
+impl<C, F, T> MapGet<C, F, T> for (Shr, Ref)
+where
+    C: NativeClass,
+    C::UserData: Map,
+    T: ToVariant,
+    F: 'static + Fn(&C, C::Base) -> &T,
+{
+    type Err = <C::UserData as Map>::Err;
+    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+        user_data.map(|rust_ty| op(rust_ty, owner).to_variant())
+    }
+}
+
+impl<C, F, T> MapGet<C, F, T> for (Mut, Owned)
+where
+    C: NativeClass,
+    C::UserData: MapMut,
+    T: ToVariant,
+    F: 'static + Fn(&mut C, C::Base) -> T,
+{
+    type Err = <C::UserData as MapMut>::Err;
+    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+        user_data.map_mut(|rust_ty| op(rust_ty, owner).to_variant())
+    }
+}
+
+impl<C, F, T> MapGet<C, F, T> for (Mut, Ref)
+where
+    C: NativeClass,
+    C::UserData: MapMut,
+    T: ToVariant,
+    F: 'static + Fn(&mut C, C::Base) -> &T,
+{
+    type Err = <C::UserData as MapMut>::Err;
+    fn map_get(user_data: &C::UserData, op: &F, owner: C::Base) -> Result<Variant, Self::Err> {
+        user_data.map_mut(|rust_ty| op(rust_ty, owner).to_variant())
+    }
+}
+
+unsafe impl<SelfArg, F, C, T> RawSetter<C, T> for Setter<SelfArg, F>
+where
+    C: NativeClass,
+    T: FromVariant,
+    SelfArg: MapSet<C, F, T>,
+{
+    unsafe fn as_godot_function(self) -> sys::godot_property_set_func {
+        let mut set = sys::godot_property_set_func::default();
+        let data = Box::new(self.func);
+        set.method_data = Box::into_raw(data) as *mut _;
+
+        extern "C" fn invoke<SelfArg, C, F, T>(
+            this: *mut sys::godot_object,
+            method: *mut libc::c_void,
+            class: *mut libc::c_void,
+            val: *mut sys::godot_variant,
+        ) where
+            C: NativeClass,
+            T: FromVariant,
+            SelfArg: MapSet<C, F, T>,
+        {
+            unsafe {
+                let user_data = C::UserData::clone_from_user_data_unchecked(class as *const _);
+                let owner = C::Base::from_sys(this);
+                let func = &*(method as *const F);
+
+                match T::from_variant(Variant::cast_ref(val)) {
+                    Ok(val) => {
+                        if let Err(err) = SelfArg::map_set(&user_data, func, owner, val) {
+                            godot_error!("gdnative-core: cannot call property setter: {:?}", err);
+                        }
+                    }
+                    Err(err) => {
+                        godot_error!("Incorrect type passed to property: {}", err);
+                    }
+                }
+            }
+        }
+        set.set_func = Some(invoke::<SelfArg, C, F, T>);
+
+        extern "C" fn free_func<F>(data: *mut libc::c_void) {
+            unsafe {
+                drop(Box::from_raw(data as *mut F));
+            }
+        }
+        set.free_func = Some(free_func::<F>);
+
+        set
+    }
+}
+
+unsafe impl<SelfArg, RetKind, F, C, T> RawGetter<C, T> for Getter<SelfArg, RetKind, F>
+where
+    C: NativeClass,
+    T: ToVariant,
+    (SelfArg, RetKind): MapGet<C, F, T>,
+{
+    unsafe fn as_godot_function(self) -> sys::godot_property_get_func {
+        let mut get = sys::godot_property_get_func::default();
+        let data = Box::new(self.func);
+        get.method_data = Box::into_raw(data) as *mut _;
+
+        extern "C" fn invoke<SelfArg, RetKind, C, F, T>(
+            this: *mut sys::godot_object,
+            method: *mut libc::c_void,
+            class: *mut libc::c_void,
+        ) -> sys::godot_variant
+        where
+            C: NativeClass,
+            T: ToVariant,
+            (SelfArg, RetKind): MapGet<C, F, T>,
+        {
+            unsafe {
+                let user_data = C::UserData::clone_from_user_data_unchecked(class as *const _);
+                let owner = C::Base::from_sys(this);
+                let func = &*(method as *const F);
+                match <(SelfArg, RetKind)>::map_get(&user_data, func, owner) {
+                    Ok(variant) => variant.forget(),
+                    Err(err) => {
+                        godot_error!("gdnative-core: cannot call property getter: {:?}", err);
+                        Variant::new().to_sys()
+                    }
+                }
+            }
+        }
+        get.get_func = Some(invoke::<SelfArg, RetKind, C, F, T>);
+
+        extern "C" fn free_func<F>(data: *mut libc::c_void) {
+            unsafe {
+                drop(Box::from_raw(data as *mut F));
+            }
+        }
+        get.free_func = Some(free_func::<F>);
+
+        get
+    }
+}

--- a/gdnative-core/src/init/property/accessor/invalid.rs
+++ b/gdnative-core/src/init/property/accessor/invalid.rs
@@ -1,0 +1,113 @@
+//! Accessors indicating that no valid accessors are present.
+
+use std::mem;
+
+use libc;
+
+use crate::FromVariant;
+use crate::NativeClass;
+use crate::ToVariant;
+use crate::Variant;
+
+use super::{RawGetter, RawSetter};
+
+/// Default setter used for a new property indicating that no valid setter is present. Outputs errors when invoked.
+#[derive(Debug)]
+pub struct InvalidSetter<'l> {
+    property_name: &'l str,
+}
+
+/// Default getter used for a new property indicating that no valid getter is present. Outputs errors when invoked.
+#[derive(Debug)]
+pub struct InvalidGetter<'l> {
+    property_name: &'l str,
+}
+
+impl<'l> InvalidSetter<'l> {
+    pub fn new(property_name: &'l str) -> Self {
+        InvalidSetter { property_name }
+    }
+}
+
+impl<'l> InvalidGetter<'l> {
+    pub fn new(property_name: &'l str) -> Self {
+        InvalidGetter { property_name }
+    }
+}
+
+#[derive(Debug)]
+struct InvalidAccessorData {
+    class_name: String,
+    property_name: String,
+}
+
+extern "C" fn invalid_setter(
+    _this: *mut sys::godot_object,
+    data: *mut libc::c_void,
+    _class: *mut libc::c_void,
+    _val: *mut sys::godot_variant,
+) {
+    let InvalidAccessorData {
+        class_name,
+        property_name,
+    } = unsafe { &*(data as *const InvalidAccessorData) };
+    godot_error!(
+        "property {} on native class {} does not have a setter",
+        property_name,
+        class_name
+    );
+}
+
+extern "C" fn invalid_getter(
+    _this: *mut sys::godot_object,
+    data: *mut libc::c_void,
+    _class: *mut libc::c_void,
+) -> sys::godot_variant {
+    let InvalidAccessorData {
+        class_name,
+        property_name,
+    } = unsafe { &*(data as *const InvalidAccessorData) };
+    godot_error!(
+        "property {} on native class {} does not have a getter",
+        property_name,
+        class_name
+    );
+    Variant::new().forget()
+}
+
+extern "C" fn invalid_free_func(data: *mut libc::c_void) {
+    let data = unsafe { Box::from_raw(data as *mut InvalidAccessorData) };
+    mem::drop(data)
+}
+
+unsafe impl<'l, C: NativeClass, T: FromVariant> RawSetter<C, T> for InvalidSetter<'l> {
+    unsafe fn as_godot_function(self) -> sys::godot_property_set_func {
+        let mut set = sys::godot_property_set_func::default();
+
+        let data = Box::new(InvalidAccessorData {
+            class_name: C::class_name().to_string(),
+            property_name: self.property_name.to_string(),
+        });
+
+        set.method_data = Box::into_raw(data) as *mut _;
+        set.set_func = Some(invalid_setter);
+        set.free_func = Some(invalid_free_func);
+        set
+    }
+}
+
+unsafe impl<'l, C: NativeClass, T: ToVariant> RawGetter<C, T> for InvalidGetter<'l> {
+    unsafe fn as_godot_function(self) -> sys::godot_property_get_func {
+        let mut get = sys::godot_property_get_func::default();
+
+        let data = Box::new(InvalidAccessorData {
+            class_name: C::class_name().to_string(),
+            property_name: self.property_name.to_string(),
+        });
+
+        get.method_data = Box::into_raw(data) as *mut _;
+        get.get_func = Some(invalid_getter);
+        get.free_func = Some(invalid_free_func);
+        get
+    }
+}

--- a/gdnative-core/src/init/property/hint.rs
+++ b/gdnative-core/src/init/property/hint.rs
@@ -1,0 +1,387 @@
+//! Strongly typed property hints.
+
+use std::fmt::{self, Write};
+use std::ops::RangeInclusive;
+
+use crate::GodotString;
+use crate::VariantType;
+
+use super::ExportInfo;
+
+/// Hints that an integer or float property should be within an inclusive range.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```rust
+/// use gdnative_core::init::property::hint::RangeHint;
+///
+/// let hint: RangeHint<f64> = RangeHint::new(0.0, 20.0).or_greater();
+/// ```
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub struct RangeHint<T> {
+    /// Minimal value, inclusive
+    pub min: T,
+    /// Maximal value, inclusive
+    pub max: T,
+    /// Optional step value for the slider
+    pub step: Option<T>,
+    /// Allow manual input above the `max` value
+    pub or_greater: bool,
+    /// Allow manual input below the `min` value
+    pub or_lesser: bool,
+}
+
+impl<T> RangeHint<T>
+where
+    T: fmt::Display,
+{
+    /// Creates a new `RangeHint`.
+    pub fn new(min: T, max: T) -> Self {
+        RangeHint {
+            min,
+            max,
+            step: None,
+            or_greater: false,
+            or_lesser: false,
+        }
+    }
+
+    /// Builder-style method that returns `self` with the given step.
+    pub fn with_step(mut self, step: T) -> Self {
+        self.step.replace(step);
+        self
+    }
+
+    /// Builder-style method that returns `self` with the `or_greater` hint.
+    pub fn or_greater(mut self) -> Self {
+        self.or_greater = true;
+        self
+    }
+
+    /// Builder-style method that returns `self` with the `or_lesser` hint.
+    pub fn or_lesser(mut self) -> Self {
+        self.or_lesser = true;
+        self
+    }
+
+    /// Formats the hint as a Godot hint string.
+    pub fn to_godot_hint_string(&self) -> GodotString {
+        let mut s = String::new();
+
+        write!(s, "{},{}", self.min, self.max).unwrap();
+        if let Some(step) = &self.step {
+            write!(s, ",{}", step).unwrap();
+        }
+
+        if self.or_greater {
+            s.push_str(",or_greater");
+        }
+        if self.or_lesser {
+            s.push_str(",or_lesser");
+        }
+
+        s.into()
+    }
+}
+
+impl<T> From<RangeInclusive<T>> for RangeHint<T>
+where
+    T: fmt::Display,
+{
+    fn from(range: RangeInclusive<T>) -> Self {
+        let (min, max) = range.into_inner();
+        RangeHint::new(min, max)
+    }
+}
+
+/// Hints that an integer, float or string property is an enumerated value to pick in a list.
+///
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```rust
+/// use gdnative_core::init::property::hint::EnumHint;
+///
+/// let hint = EnumHint::new(vec!["Foo".into(), "Bar".into(), "Baz".into()]);
+/// ```
+#[derive(Clone, Eq, PartialEq, Debug, Default)]
+pub struct EnumHint {
+    values: Vec<String>,
+}
+
+impl EnumHint {
+    pub fn new(values: Vec<String>) -> Self {
+        EnumHint { values }
+    }
+
+    /// Formats the hint as a Godot hint string.
+    pub fn to_godot_hint_string(&self) -> GodotString {
+        let mut s = String::new();
+
+        let mut iter = self.values.iter();
+
+        if let Some(first) = iter.next() {
+            write!(s, "{}", first).unwrap();
+        }
+
+        for rest in iter {
+            write!(s, ",{}", rest).unwrap();
+        }
+
+        s.into()
+    }
+}
+
+/// Possible hints for integers.
+#[derive(Clone, Debug)]
+pub enum IntHint<T> {
+    /// Hints that an integer or float property should be within a range.
+    Range(RangeHint<T>),
+    /// Hints that an integer or float property should be within an exponential range.
+    ExpRange(RangeHint<T>),
+    /// Hints that an integer, float or string property is an enumerated value to pick in a list.
+    Enum(EnumHint),
+    /// Hints that an integer property is a bitmask with named bit flags.
+    Flags(EnumHint),
+    /// Hints that an integer property is a bitmask using the optionally named 2D render layers.
+    Layers2DRender,
+    /// Hints that an integer property is a bitmask using the optionally named 2D physics layers.
+    Layers2DPhysics,
+    /// Hints that an integer property is a bitmask using the optionally named 3D render layers.
+    Layers3DRender,
+    /// Hints that an integer property is a bitmask using the optionally named 3D physics layers.
+    Layers3DPhysics,
+}
+
+impl<T> IntHint<T>
+where
+    T: fmt::Display,
+{
+    pub fn export_info(self) -> ExportInfo {
+        use IntHint as IH;
+
+        let hint_kind = match &self {
+            IH::Range(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_RANGE,
+            IH::ExpRange(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_EXP_RANGE,
+            IH::Enum(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_ENUM,
+            IH::Flags(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_FLAGS,
+            IH::Layers2DRender => sys::godot_property_hint_GODOT_PROPERTY_HINT_LAYERS_2D_RENDER,
+            IH::Layers2DPhysics => sys::godot_property_hint_GODOT_PROPERTY_HINT_LAYERS_2D_PHYSICS,
+            IH::Layers3DRender => sys::godot_property_hint_GODOT_PROPERTY_HINT_LAYERS_3D_RENDER,
+            IH::Layers3DPhysics => sys::godot_property_hint_GODOT_PROPERTY_HINT_LAYERS_3D_PHYSICS,
+        };
+
+        let hint_string = match self {
+            IH::Range(range) | IH::ExpRange(range) => range.to_godot_hint_string(),
+            IH::Enum(e) | IH::Flags(e) => e.to_godot_hint_string(),
+            _ => GodotString::new(),
+        };
+
+        ExportInfo {
+            variant_type: VariantType::I64,
+            hint_kind,
+            hint_string,
+        }
+    }
+}
+
+impl<T> From<RangeHint<T>> for IntHint<T>
+where
+    T: fmt::Display,
+{
+    fn from(hint: RangeHint<T>) -> Self {
+        Self::Range(hint)
+    }
+}
+
+impl<T> From<RangeInclusive<T>> for IntHint<T>
+where
+    T: fmt::Display,
+{
+    fn from(range: RangeInclusive<T>) -> Self {
+        Self::Range(range.into())
+    }
+}
+
+impl<T> From<EnumHint> for IntHint<T> {
+    fn from(hint: EnumHint) -> Self {
+        Self::Enum(hint)
+    }
+}
+
+/// Hints that a float property should be edited via an exponential easing function.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub struct ExpEasingHint {
+    /// Flip the curve horizontally.
+    pub is_attenuation: bool,
+    /// Also include in/out easing.
+    pub is_in_out: bool,
+}
+
+impl ExpEasingHint {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Formats the hint as a Godot hint string.
+    pub fn to_godot_hint_string(&self) -> GodotString {
+        let mut s = String::new();
+
+        let mut is_second = false;
+
+        if self.is_attenuation {
+            s.push_str("attenuation");
+            is_second = true;
+        }
+
+        if self.is_in_out {
+            if is_second {
+                s.push(',');
+            }
+            s.push_str("inout");
+        }
+
+        s.into()
+    }
+}
+
+/// Possible hints for floats.
+#[derive(Clone, Debug)]
+pub enum FloatHint<T> {
+    /// Hints that an integer or float property should be within a range.
+    Range(RangeHint<T>),
+    /// Hints that an integer or float property should be within an exponential range.
+    ExpRange(RangeHint<T>),
+    /// Hints that an integer, float or string property is an enumerated value to pick in a list.
+    Enum(EnumHint),
+    /// Hints that a float property should be edited via an exponential easing function.
+    ExpEasing(ExpEasingHint),
+}
+
+impl<T> FloatHint<T>
+where
+    T: fmt::Display,
+{
+    pub fn export_info(self) -> ExportInfo {
+        use FloatHint as FH;
+
+        let hint_kind = match &self {
+            FH::Range(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_RANGE,
+            FH::ExpRange(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_EXP_RANGE,
+            FH::Enum(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_ENUM,
+            FH::ExpEasing(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_EXP_EASING,
+        };
+
+        let hint_string = match self {
+            FH::Range(range) | FH::ExpRange(range) => range.to_godot_hint_string(),
+            FH::Enum(e) => e.to_godot_hint_string(),
+            FH::ExpEasing(e) => e.to_godot_hint_string(),
+        };
+
+        ExportInfo {
+            variant_type: VariantType::F64,
+            hint_kind,
+            hint_string,
+        }
+    }
+}
+
+impl<T> From<RangeHint<T>> for FloatHint<T>
+where
+    T: fmt::Display,
+{
+    fn from(hint: RangeHint<T>) -> Self {
+        Self::Range(hint)
+    }
+}
+
+impl<T> From<RangeInclusive<T>> for FloatHint<T>
+where
+    T: fmt::Display,
+{
+    fn from(range: RangeInclusive<T>) -> Self {
+        Self::Range(range.into())
+    }
+}
+
+impl<T> From<EnumHint> for FloatHint<T> {
+    fn from(hint: EnumHint) -> Self {
+        Self::Enum(hint)
+    }
+}
+
+impl<T> From<ExpEasingHint> for FloatHint<T> {
+    fn from(hint: ExpEasingHint) -> Self {
+        Self::ExpEasing(hint)
+    }
+}
+
+/// Possible hints for strings.
+#[derive(Clone, Debug)]
+pub enum StringHint {
+    /// Hints that an integer, float or string property is an enumerated value to pick in a list.
+    Enum(EnumHint),
+    /// Hints that a string property is a path to a file.
+    File(EnumHint),
+    /// Hints that a string property is an absolute path to a file outside the project folder.
+    GlobalFile(EnumHint),
+    /// Hints that a string property is a path to a directory.
+    Dir,
+    /// Hints that a string property is an absolute path to a directory outside the project folder.
+    GlobalDir,
+    /// Hints that a string property is text with line breaks.
+    Multiline,
+    /// Hints that a string property should have a placeholder text visible on its input field, whenever the property is empty.
+    Placeholder { placeholder: String },
+}
+
+impl StringHint {
+    pub fn export_info(self) -> ExportInfo {
+        use StringHint as SH;
+
+        let hint_kind = match &self {
+            SH::Enum(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_ENUM,
+            SH::File(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_FILE,
+            SH::GlobalFile(_) => sys::godot_property_hint_GODOT_PROPERTY_HINT_GLOBAL_FILE,
+            SH::Dir => sys::godot_property_hint_GODOT_PROPERTY_HINT_DIR,
+            SH::GlobalDir => sys::godot_property_hint_GODOT_PROPERTY_HINT_GLOBAL_DIR,
+            SH::Multiline => sys::godot_property_hint_GODOT_PROPERTY_HINT_MULTILINE_TEXT,
+            SH::Placeholder { .. } => sys::godot_property_hint_GODOT_PROPERTY_HINT_PLACEHOLDER_TEXT,
+        };
+
+        let hint_string = match self {
+            SH::Enum(e) | SH::File(e) | SH::GlobalFile(e) => e.to_godot_hint_string(),
+            SH::Placeholder { placeholder } => placeholder.into(),
+            _ => GodotString::new(),
+        };
+
+        ExportInfo {
+            variant_type: VariantType::GodotString,
+            hint_kind,
+            hint_string,
+        }
+    }
+}
+
+/// Possible hints for `Color`.
+#[derive(Clone, Debug)]
+pub enum ColorHint {
+    /// Hints that a color property should be edited without changing its alpha component.
+    NoAlpha,
+}
+
+impl ColorHint {
+    pub fn export_info(self) -> ExportInfo {
+        ExportInfo {
+            variant_type: VariantType::Color,
+            hint_kind: match self {
+                ColorHint::NoAlpha => sys::godot_property_hint_GODOT_PROPERTY_HINT_COLOR_NO_ALPHA,
+            },
+            hint_string: GodotString::new(),
+        }
+    }
+}

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -186,6 +186,12 @@ impl GodotString {
     }
 }
 
+impl Clone for GodotString {
+    fn clone(&self) -> Self {
+        self.new_ref()
+    }
+}
+
 impl_basic_traits!(
     for GodotString as godot_string {
         Drop => godot_string_destroy;

--- a/gdnative-derive/src/native_script/property_args.rs
+++ b/gdnative-derive/src/native_script/property_args.rs
@@ -1,9 +1,11 @@
 pub struct PropertyAttrArgs {
-    pub default: syn::Lit,
+    pub path: Option<String>,
+    pub default: Option<syn::Lit>,
 }
 
 #[derive(Default)]
 pub struct PropertyAttrArgsBuilder {
+    path: Option<String>,
     default: Option<syn::Lit>,
 }
 
@@ -24,6 +26,17 @@ impl<'a> Extend<&'a syn::MetaNameValue> for PropertyAttrArgsBuilder {
                         panic!("there is already a default value set: {:?}", old);
                     }
                 }
+                "path" => {
+                    let string = if let syn::Lit::Str(lit_str) = &pair.lit {
+                        lit_str.value()
+                    } else {
+                        panic!("path value is not a string literal");
+                    };
+
+                    if let Some(old) = self.path.replace(string) {
+                        panic!("there is already a path set: {:?}", old);
+                    }
+                }
                 _ => panic!("unexpected argument: {}", &name),
             }
         }
@@ -33,7 +46,8 @@ impl<'a> Extend<&'a syn::MetaNameValue> for PropertyAttrArgsBuilder {
 impl PropertyAttrArgsBuilder {
     pub fn done(self) -> PropertyAttrArgs {
         PropertyAttrArgs {
-            default: self.default.expect("`default` value is required"),
+            path: self.path,
+            default: self.default,
         }
     }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -45,6 +45,7 @@ pub extern "C" fn run_tests(
     status &= test_owner_free_ub();
 
     status &= test_variant_call_args();
+    status &= test_register_property();
 
     gdnative::Variant::from_bool(status).forget()
 }
@@ -359,7 +360,7 @@ impl NativeClass for RegisterSignal {
             args: &[gdnative::init::SignalArgument {
                 name: "amount",
                 default: gdnative::Variant::new(),
-                hint: gdnative::init::PropertyHint::None,
+                export_info: init::ExportInfo::new(VariantType::I64),
                 usage: gdnative::init::PropertyUsage::DEFAULT,
             }],
         });
@@ -368,6 +369,71 @@ impl NativeClass for RegisterSignal {
 
 #[methods]
 impl RegisterSignal {}
+
+struct RegisterProperty {
+    value: i64,
+}
+
+impl NativeClass for RegisterProperty {
+    type Base = Reference;
+    type UserData = user_data::MutexData<RegisterProperty>;
+    fn class_name() -> &'static str {
+        "RegisterProperty"
+    }
+    fn init(_owner: Reference) -> RegisterProperty {
+        RegisterProperty { value: 42 }
+    }
+    fn register_properties(builder: &init::ClassBuilder<Self>) {
+        builder
+            .add_property("value")
+            .with_default(42)
+            .with_setter(RegisterProperty::set_value)
+            .with_getter(RegisterProperty::get_value)
+            .done();
+    }
+}
+
+#[methods]
+impl RegisterProperty {
+    #[export]
+    fn set_value(&mut self, _owner: Reference, value: i64) {
+        self.value = value;
+    }
+
+    #[export]
+    fn get_value(&self, _owner: Reference) -> i64 {
+        self.value
+    }
+}
+
+fn test_register_property() -> bool {
+    println!(" -- test_register_property");
+
+    let ok = std::panic::catch_unwind(|| {
+        let obj = Instance::<RegisterProperty>::new();
+
+        let mut base = obj.into_base();
+
+        unsafe {
+            assert_eq!(Some(42), base.call("get_value".into(), &[]).try_to_i64());
+
+            base.set("value".into(), 54.to_variant());
+
+            assert_eq!(Some(54), base.call("get_value".into(), &[]).try_to_i64());
+
+            base.call("set_value".into(), &[4242.to_variant()]);
+
+            assert_eq!(Some(4242), base.call("get_value".into(), &[]).try_to_i64());
+        }
+    })
+    .is_ok();
+
+    if !ok {
+        godot_error!("   !! Test test_register_property failed");
+    }
+
+    ok
+}
 
 struct VariantCallArgs;
 
@@ -463,6 +529,7 @@ fn init(handle: init::InitHandle) {
     handle.add_class::<Foo>();
     handle.add_class::<Bar>();
     handle.add_class::<RegisterSignal>();
+    handle.add_class::<RegisterProperty>();
     handle.add_class::<VariantCallArgs>();
 }
 


### PR DESCRIPTION
The original Property API was flawed in a few ways, requiring a breaking change to fix:
    
- VariantType was derived from the default value, making it mandatory. The new API can export properties without default values.
- Self argument type was tied to accessor direction. Since the user-data wrapper can now be customized, setters with `&self` or getters with `&mut self` are actually acceptable. The new API accounts for this.
- Accessors with non-static lifetimes were accepted. This can obviously cause UB, so `'static` bounds are added.
- Accessors were unable to take the `owner` object as an argument. This has been fixed.

The new API also improves on usability:

- Properties are constructed with the builder pattern. Users no longer have to type out the entire Property struct when registering properties.
- Export hints are strongly typed, statically preventing invalid hints.
- The `FromVariant` bound on types of exported properties is removed, so it's possible to export a `ToVariant` only type as a readonly property.

Some changes are made to the property macro:

- The `default` argument is no longer required.
- Fixed `base/` prefix and added the optional `path` argument, allowing users to rename exported properties.

Close #277

## Explanation

In the new interface, properties are registered using the builder pattern:

```rust
builder
    .add_property("foo")
    .default(0.0)
    .with_hint((-10.0..=30.0).into())
    // accessors now have the same signatures as normal exported methods, so it's possible to just use them
    .with_getter(MyType::get_foo)
    .with_setter(MyType::set_foo)
    .done();

builder
    // turbofish may be necessary when there isn't a default value
    .add_property::<String>("test/test_enum")
    .with_hint(StringHint::Enum(EnumHint::new(&[
        "Hello", "World", "Testing",
    ])))
    .with_getter(|_, _| "Hello".into())
    .done();
```

As seen above, the hints are strongly typed, preventing invalid ones from being registered. This is done through the `Export` trait, which associates with each exportable type a distinct hint type:

```rust
pub trait Export: ToVariant {
    type Hint;
    fn export_info(hint: Option<Self::Hint>) -> ExportInfo;
}

#[derive(Debug)]
pub struct ExportInfo {
    pub variant_type: VariantType,
    pub hint_kind: sys::godot_property_hint,
    pub hint_string: GodotString,
}
```

The `export_info` method is defined on the `Export` trait, instead of the associated hint type, because unlike the hint, it has access to the exported type. This can be seen in the blanket `Export` implementation for the generated binding types, where the hint string is generated from the class's name:

```rust
impl<T> Export for T
where
    T: GodotObject + ToVariant,
{
    type Hint = ();
    fn export_info(_hint: Option<Self::Hint>) -> ExportInfo {
        // manually inlined for clarity
        ExportInfo {
            variant_type: VariantType::Object,
            hint_kind: sys::godot_property_hint_GODOT_PROPERTY_HINT_RESOURCE_TYPE,
            hint_string: T::class_name().into(),
        }
    }
}
```

The `Export` trait can also be implemented by the user on custom types, if custom behavior is somehow needed.

## Rationale and alternatives

It is possible to keep having users manually fill out a `Property` struct as before, but manually producing the `(variant_type, hint_kind, hint_string)` triplet can be quite error-prone, and the syntax would have been rather hideous. By introducing a builder, the interface is kept saner.

I'm not quite sure about `add_property` taking `&self`. I think `ClassBuilder` should have had `&mut` methods from the beginning, but changing it now can be tricky since existing code already depend on `ClassBuilder` being usable behind `&` references. This is already a huge patch, and another big breaking change should be a separate issue.

## Unresolved questions

Hopefully none.

## Future possibilities

Signal registration could use a similar interface as well, if the changes prove successful, since it also involves the fields in `ExportInfo`.