### PR TITLE
Always generate Drop for reference counted types

### DIFF
--- a/bindings_generator/src/lib.rs
+++ b/bindings_generator/src/lib.rs
@@ -159,9 +159,6 @@ fn generate_class_bindings(
 
         if class.is_refcounted() {
             generate_reference_clone(output_trait_impls, class)?;
-        }
-
-        if class.is_refcounted() && class.instanciable {
             generate_drop(output_trait_impls, class)?;
         }
 


### PR DESCRIPTION
For some reason, Drop implementations were not generated for non-instanciable classes. This caused memory leaks in some cases like the InputEvent argument for the _input and _unhandled_input events. Removing this condition should fix the problem.