### PR TITLE
Assorted fixes for gdnative-sys

### DIFF
--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -138,6 +138,16 @@ mod api_wrapper {
             let mut result = Vec::new();
             result.extend(self.core.nexts());
             for extension in &self.extensions {
+                // Workaround: Interface for the ANDROID extension is broken in Godot 3.2,
+                // making it impossible to support the extension in a forward compatible manner.
+                // The extension is disabled until the compatibility policy is figured out in
+                // upstream.
+                //
+                // Related issue: #296
+                if extension.type_ == "ANDROID" {
+                    continue;
+                }
+
                 result.extend(extension.nexts());
             }
             result

--- a/gdnative-sys/src/lib.rs
+++ b/gdnative-sys/src/lib.rs
@@ -14,13 +14,13 @@ unsafe fn find_api_ptr(
     version_minor: u32,
 ) -> *const godot_gdnative_api_struct {
     let mut api = core_api as *const godot_gdnative_api_struct;
-    if (*api).type_ == api_type {
+    if (*api).type_ as u32 == api_type as u32 {
         while !api.is_null() {
             if (*api).version.minor == version_minor
                 && (*api).version.major == version_major
                 // The boolean expression below SHOULD always be true;
                 // we will double check to be safe.
-                && (*api).type_ == api_type
+                && (*api).type_ as u32 == api_type as u32
             {
                 return api;
             }
@@ -30,13 +30,13 @@ unsafe fn find_api_ptr(
     for i in 0..(*core_api).num_extensions {
         let mut extension =
             *(*core_api).extensions.offset(i as _) as *const godot_gdnative_api_struct;
-        if (*extension).type_ == api_type {
+        if (*extension).type_ as u32 == api_type as u32 {
             while !extension.is_null() {
                 if (*extension).version.minor == version_minor
                     && (*extension).version.major == version_major
                     // The boolean expression below SHOULD always be true;
                     // we will double check to be safe.
-                    && (*extension).type_ == api_type
+                    && (*extension).type_ as u32 == api_type as u32
                 {
                     return extension;
                 }
@@ -45,7 +45,8 @@ unsafe fn find_api_ptr(
         }
     }
     panic!(
-        "Couldn't find API: {:?}",
-        (api_type, version_major, version_minor)
+        "Couldn't find API struct with type {type}, version {version:?}",
+        type = api_type,
+        version = (version_major, version_minor),
     );
 }


### PR DESCRIPTION
- Fixed type mismatch error on Windows due to enum repr difference
- Ignored the Android extension due to incompatibility
- Improved error message when necessary API structs are not found

Close #296. Close #297.