### PR TITLE
Make LocalCellData the default user-data wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ use gdnative::*;
 /// The HelloWorld "class"
 #[derive(NativeClass)]
 #[inherit(Node)]
-#[user_data(user_data::ArcData<HelloWorld>)]
 pub struct HelloWorld;
 
 // __One__ `impl` block can have the `#[methods]` attribute, which will generate

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -3,7 +3,6 @@ extern crate gdnative;
 
 #[derive(gdnative::NativeClass)]
 #[inherit(gdnative::Node)]
-#[user_data(gdnative::user_data::ArcData<HelloWorld>)]
 struct HelloWorld;
 
 #[gdnative::methods]

--- a/examples/spinning_cube/src/lib.rs
+++ b/examples/spinning_cube/src/lib.rs
@@ -5,7 +5,6 @@ use gdnative::init::property::{EnumHint, IntHint, StringHint};
 
 #[derive(gdnative::NativeClass)]
 #[inherit(gdnative::MeshInstance)]
-#[user_data(gdnative::user_data::MutexData<RustTest>)]
 #[register_with(my_register_function)]
 struct RustTest {
     start: gdnative::Vector3,

--- a/gdnative-core/src/user_data.rs
+++ b/gdnative-core/src/user_data.rs
@@ -97,7 +97,7 @@ pub trait MapMut: UserData {
 
 /// The default user data wrapper used by derive macro, when no `user_data` attribute is present.
 /// This may change in the future.
-pub type DefaultUserData<T> = MutexData<T, DefaultLockPolicy>;
+pub type DefaultUserData<T> = LocalCellData<T>;
 
 /// Error type indicating that an operation can't fail.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]


### PR DESCRIPTION
Many new users experience problems with `ArcData` being used in the Hello World example. It should be a fair compromise to make it a run time error to access instances from threads by default in order to ease the learning curve.