### PR TITLE
Fix new_ref() documentation ignored by macro

### DIFF
--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -112,7 +112,6 @@ impl ByteArray {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(& self) -> ByteArray : godot_pool_byte_array_new_copy;
     }
 }

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -116,7 +116,6 @@ impl ColorArray {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> ColorArray : godot_pool_color_array_new_copy;
     }
 }

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -109,7 +109,6 @@ impl Dictionary {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this dictionary.
         pub fn new_ref(&self) -> Dictionary : godot_dictionary_new_copy;
     }
 }

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -112,7 +112,6 @@ impl Float32Array {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> Float32Array : godot_pool_real_array_new_copy;
     }
 }

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -112,7 +112,6 @@ impl Int32Array {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(& self) -> Int32Array : godot_pool_int_array_new_copy;
     }
 }

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -312,8 +312,8 @@ macro_rules! impl_common_methods {
         )*
     ) => (
         $(
-            $(#[$attr])*
             impl_common_method!(
+                $(#[$attr])*
                 pub fn $name(&self $(,$pname : $pty)*) -> $Ty : $gd_method
             );
         )*

--- a/gdnative-core/src/macros.rs
+++ b/gdnative-core/src/macros.rs
@@ -293,6 +293,7 @@ macro_rules! impl_common_method {
         pub fn new_ref(&self) -> $Type:ident : $gd_method:ident
     ) => {
         $(#[$attr])*
+        /// Creates a new reference to this reference-counted instance.
         pub fn new_ref(&self) -> $Type {
             unsafe {
                 let mut result = Default::default();

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -103,7 +103,6 @@ impl NodePath {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this node path.
         pub fn new_ref(&self) -> NodePath : godot_node_path_new_copy;
     }
 }

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -181,7 +181,6 @@ impl GodotString {
     // TODO: many missing methods.
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> GodotString : godot_string_new_copy;
     }
 }

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -113,7 +113,6 @@ impl StringArray {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> StringArray : godot_pool_string_array_new_copy;
     }
 }

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -175,7 +175,6 @@ impl VariantArray {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> VariantArray : godot_array_new_copy;
     }
 }

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -116,7 +116,6 @@ impl Vector2Array {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> Vector2Array : godot_pool_vector2_array_new_copy;
     }
 }

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -116,7 +116,6 @@ impl Vector3Array {
     }
 
     impl_common_methods! {
-        /// Creates a new reference to this array.
         pub fn new_ref(&self) -> Vector3Array : godot_pool_vector3_array_new_copy;
     }
 }


### PR DESCRIPTION
With newer Rust compiler versions, I get a lot of warnings, following is just one example. I currently use _rustc 1.44.0-nightly (f509b26a7 2020-03-18)_, with the macro call site visible.

```
   Compiling gdnative-core v0.8.0 (C:\...\godot-rust\gdnative-core)
warning: unused doc comment
   --> C:\...\godot-rust\gdnative-core\src\macros.rs:314:15
    |
314 |               $(#[$attr])*
    |                 ^^^^^^^^ rustdoc does not generate documentation for macros
    | 
   ::: C:\...\godot-rust\gdnative-core\src\byte_array.rs:114:5
    |
114 | /     impl_common_methods! {
115 | |         /// Creates a new reference to this array.
116 | |         pub fn new_ref(& self) -> ByteArray : godot_pool_byte_array_new_copy;
117 | |     }
    | |_____- in this macro invocation
    |
    = note: `#[warn(unused_doc_comments)]` on by default
    = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

It is true that `ByteArray.new_ref()` does not contain any documentation, see [Docs.rs](https://docs.rs/gdnative/0.8.0/gdnative/struct.ByteArray.html#method.new_ref).

The problem is that the doc comment here:
```rust
impl_common_methods! {
     /// Creates a new reference to this array.
     pub fn new_ref(& self) -> ByteArray : godot_pool_byte_array_new_copy;
}
```
will not be part of the expanded macro. Instead, we need the macro expansion to contain it.

The documentation is practically the same for all occurrences, with the difference only in the mention of the _Self_ type. Therefore, I thought it would make sense to have it centrally in the `impl_common_methods` macro definition, using a `#[doc]` attribute. I used the chance to make the doc string slightly more expressive:
```rust
#[doc="Creates a new reference to this reference-counted instance."]
```

Let me know if there are any changes necessary.