### PR TITLE
Fix apparent freeze when building -sys with --release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
       rust: stable
       env: CI_STAGE_CARGO_TEST=yes
 
+    - name: cargo build --release (stable)
+      os: linux
+      rust: stable
+      env: CI_STAGE_BUILD_RELEASE=yes
+
     - name: Godot test (stable)
       os: linux
       rust: stable
@@ -32,6 +37,11 @@ matrix:
       os: linux
       rust: nightly
       env: CI_STAGE_CARGO_TEST=yes
+
+    - name: cargo build --release (nightly)
+      os: linux
+      rust: nightly
+      env: CI_STAGE_BUILD_RELEASE=yes
 
     - name: Godot test (nightly)
       os: linux
@@ -47,10 +57,20 @@ matrix:
       rust: stable
       env: CI_STAGE_CARGO_TEST=yes
 
+    - name: cargo build --release (stable, windows)
+      os: windows
+      rust: stable
+      env: CI_STAGE_BUILD_RELEASE=yes
+
     - name: cargo test (nightly, windows)
       os: windows
       rust: nightly
       env: CI_STAGE_CARGO_TEST=yes
+
+    - name: cargo build --release (nightly, windows)
+      os: windows
+      rust: nightly
+      env: CI_STAGE_BUILD_RELEASE=yes
 
 script:
   - if [[ "$CI_STAGE_CARGO_FMT" == "yes" ]]; then
@@ -59,6 +79,10 @@ script:
 
   - if [[ "$CI_STAGE_CARGO_TEST" == "yes" ]]; then
       cargo test --all --all-features;
+    fi
+
+  - if [[ "$CI_STAGE_BUILD_RELEASE" == "yes" ]]; then
+      cargo build --release;
     fi
 
   - if [[ "$CI_STAGE_GODOT_TEST" == "yes" ]]; then

--- a/gdnative-sys/src/lib.rs
+++ b/gdnative-sys/src/lib.rs
@@ -7,6 +7,7 @@
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 include!(concat!(env!("OUT_DIR"), "/api_wrapper.rs"));
 
+#[derive(Debug)]
 pub enum InitError {
     VersionMismatch {
         api_type: GDNATIVE_API_TYPES,


### PR DESCRIPTION
rustc has trouble dealing with a large amount of returns within the same expression when optimization is enabled, causing the build to appear to halt. This problem was introduced in #309 , which used many try expressions in a single constructor.

Although the exact cause within rustc is unknown, separating the try expressions into let bindings resolved this problem.

This PR also added release builds to CI, in order to detect similar problems before merging in the future.