### PR TITLE
Run rustfmt for 1.43.0 stable release

### DIFF
--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -107,7 +107,7 @@ godot_test!(
         test(Vector2::new(1.0, 2.0), Vector2::new(3.0, 4.0));
         test(Vector2::new(3.0, 4.0), Vector2::new(5.0, 6.0));
     }
-    );
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Fix CI failure due to previously accepted syntax.