### PR TITLE
Add variant attribute to skip fields

### DIFF
--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -781,6 +781,19 @@ godot_test!(
 ///
 /// Convenience attribute that sets `to_variant_with` to `path::to::mod::to_variant` and
 /// `from_variant_with` to `path::to::mod::from_variant`.
+///
+/// - `#[variant(skip_to_variant)]`
+///
+/// Skip the field when converting to `Variant`.
+///
+/// - `#[variant(skip_from_variant)]`
+///
+/// Skip the field when converting from `Variant`. A default vale will be obtained using
+/// `Default::default()`.
+///
+/// - `#[variant(skip)]`
+///
+/// Convenience attribute that sets `skip_to_variant` and `skip_from_variant`.
 pub trait ToVariant {
     fn to_variant(&self) -> Variant;
 }

--- a/gdnative-derive/src/variant/from.rs
+++ b/gdnative-derive/src/variant/from.rs
@@ -101,6 +101,7 @@ pub(crate) fn expand_from_variant(derive_data: DeriveData) -> TokenStream {
     let where_clause = &generics.where_clause;
 
     let result = quote! {
+        #[allow(unused_variables)]
         impl #generics ::gdnative::FromVariant for #ident #generics #where_clause {
             fn from_variant(
                 #input_ident: &::gdnative::Variant

--- a/gdnative-derive/src/variant/to.rs
+++ b/gdnative-derive/src/variant/to.rs
@@ -62,6 +62,7 @@ pub(crate) fn expand_to_variant(derive_data: DeriveData) -> TokenStream {
     let where_clause = &generics.where_clause;
 
     let result = quote! {
+        #[allow(unused_variables)]
         impl #generics ::gdnative::ToVariant for #ident #generics #where_clause {
             fn to_variant(&self) -> ::gdnative::Variant {
                 use ::gdnative::ToVariant;

--- a/test/src/test_derive.rs
+++ b/test/src/test_derive.rs
@@ -14,15 +14,18 @@ fn test_derive_to_variant() -> bool {
     println!(" -- test_derive_to_variant");
 
     #[derive(Clone, Eq, PartialEq, Debug, ToVariant, FromVariant)]
-    struct ToVar<T>
+    struct ToVar<T, R>
     where
         T: Associated,
+        R: Default,
     {
         foo: T::A,
         bar: T,
         baz: ToVarEnum<T::B>,
         #[variant(with = "variant_with")]
         ptr: *mut (),
+        #[variant(skip)]
+        skipped: R,
     }
 
     #[derive(Clone, Eq, PartialEq, Debug, ToVariant, FromVariant)]
@@ -31,6 +34,12 @@ fn test_derive_to_variant() -> bool {
         Bar,
         Baz { baz: u8 },
     }
+
+    #[derive(Clone, Eq, PartialEq, Debug, ToVariant, FromVariant)]
+    struct ToVarTuple<T, R>(T::A, #[variant(skip)] R, T::B)
+    where
+        T: Associated,
+        R: Default;
 
     trait Associated {
         type A;
@@ -55,12 +64,14 @@ fn test_derive_to_variant() -> bool {
     }
 
     let ok = std::panic::catch_unwind(|| {
-        let data = ToVar::<f64> {
+        let data = ToVar::<f64, i128> {
             foo: 42,
             bar: 54.0,
             baz: ToVarEnum::Foo(true),
             ptr: std::ptr::null_mut(),
+            skipped: 42,
         };
+
         let variant = data.to_variant();
         let dictionary = variant.try_to_dictionary().expect("should be dictionary");
         assert_eq!(Some(42), dictionary.get(&"foo".into()).try_to_i64());
@@ -69,6 +80,8 @@ fn test_derive_to_variant() -> bool {
             Some("*mut ()".into()),
             dictionary.get(&"ptr".into()).try_to_string()
         );
+        assert!(!dictionary.contains(&"skipped".into()));
+
         let enum_dict = dictionary
             .get(&"baz".into())
             .try_to_dictionary()
@@ -76,10 +89,27 @@ fn test_derive_to_variant() -> bool {
         assert_eq!(Some(true), enum_dict.get(&"Foo".into()).try_to_bool());
 
         assert_eq!(
-            Ok(&data.baz),
-            ToVarEnum::from_variant(&enum_dict.to_variant()).as_ref()
+            Ok(ToVar::<f64, i128> {
+                foo: 42,
+                bar: 54.0,
+                baz: ToVarEnum::Foo(true),
+                ptr: std::ptr::null_mut(),
+                skipped: 0,
+            }),
+            ToVar::from_variant(&variant)
         );
-        assert_eq!(Ok(&data), ToVar::from_variant(&variant).as_ref());
+
+        let data = ToVarTuple::<f64, i128>(1, 2, false);
+        let variant = data.to_variant();
+        let tuple_array = variant.try_to_array().expect("should be array");
+
+        assert_eq!(2, tuple_array.len());
+        assert_eq!(Some(1), tuple_array.get_ref(0).try_to_i64());
+        assert_eq!(Some(false), tuple_array.get_ref(1).try_to_bool());
+        assert_eq!(
+            Ok(ToVarTuple::<f64, i128>(1, 0, false)),
+            ToVarTuple::from_variant(&variant)
+        );
     })
     .is_ok();
 


### PR DESCRIPTION
Adds the following flags to the `#[variant]` attribute:

- `skip_to_variant`
- `skip_from_variant`
- `skip`