### PR TITLE
Infer Android include paths from environment

### DIFF
--- a/gdnative-sys/src/lib.rs
+++ b/gdnative-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(
     non_upper_case_globals,
     non_camel_case_types,
+    non_snake_case,
     improper_ctypes,
     clippy::style
 )]


### PR DESCRIPTION
`clang-sys` is unable to detect include paths of the Android SDK, causing host system headers to be used, and subsequent generation failures. This PR adds include path detection using the `JAVA_HOME` and `ANDROID_SDK_ROOT` environment variables.

Fix #344