### PR TITLE
Add ios simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,29 @@ matrix:
       rust: nightly
       env: CI_STAGE_BUILD_RELEASE=yes
 
+    - name: cargo test ios-simulator
+      os: osx
+      osx_image: xcode11.4
+      rust: stable
+      env: CI_STAGE_IOS_SIMULATOR_TEST=yes
+      before_script:
+       - rustup target add x86_64-apple-ios
+       - cargo install cargo-dinghy
+
 script:
   - if [[ "$CI_STAGE_CARGO_FMT" == "yes" ]]; then
       cargo fmt --all -- --check;
+    fi
+
+  - if [[ "$CI_STAGE_IOS_SIMULATOR_TEST" == "yes" ]]; then
+      RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1);
+      export SIM_ID=$(xcrun simctl create My-iphone11 com.apple.CoreSimulator.SimDeviceType.iPhone-11 $RUNTIME_ID);
+      xcrun simctl boot $SIM_ID;
+      cd gdnative-core;
+      cargo dinghy --platform auto-ios-x86_64 test;
+      cd ..;
+      cd gdnative-sys;
+      cargo dinghy --platform auto-ios-x86_64 test;
     fi
 
   - if [[ "$CI_STAGE_CARGO_TEST" == "yes" ]]; then

--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -178,8 +178,6 @@ mod header_binding {
         let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let target_vendor = std::env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
 
-        // Workaround: x86_64 architecture is unsupported by the iPhone SDK, but cargo-lipo will
-        // try to build it anyway. This leads to a clang error, so we'll skip the SDK.
         if target_vendor == "apple" {
             match apple_include_path() {
                 Ok(osx_include_path) => {


### PR DESCRIPTION
Closes #352.

* `xcrun --sdk $PLATFORM --show-sdk-path` to get the sysroot 
* Adding iphonesimulator support.

I've tested verified that this builds with macos, aarch64-apple-ios (the iPhone) and for x86_64-apple-ios (the ios simulator).

I also added [`cargo-dinghy`](https://crates.io/crates/cargo-dinghy) to CI so that you can run some of the unit tests in the simulator. The tests in gdnative-sys are really just the bindgen size tests.

I tried running `cargo dinghy --platform auto-ios-x86_64 test` in the root of the project and there's some weird bug with the examples in dinghy. It could be due to lack of a local lib (like godot as a static lib?) or maybe a bug with dinghy itself. I'm not sure.