### PR TITLE
Prevent UB from panic-in-FFI situations

### DIFF
--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -58,74 +58,18 @@ impl InitHandle {
     where
         C: NativeClassMethods,
     {
-        unsafe {
-            let class_name = CString::new(C::class_name()).unwrap();
-            let base_name = CString::new(C::Base::class_name()).unwrap();
-
-            let create = {
-                unsafe extern "C" fn constructor<C: NativeClass>(
-                    this: *mut sys::godot_object,
-                    _method_data: *mut libc::c_void,
-                ) -> *mut libc::c_void {
-                    let val = C::init(C::Base::from_sys(this));
-
-                    let wrapper = C::UserData::new(val);
-                    C::UserData::into_user_data(wrapper) as *mut _
-                }
-
-                sys::godot_instance_create_func {
-                    create_func: Some(constructor::<C>),
-                    method_data: ptr::null_mut(),
-                    free_func: None,
-                }
-            };
-
-            let destroy = {
-                unsafe extern "C" fn destructor<C: NativeClass>(
-                    _this: *mut sys::godot_object,
-                    _method_data: *mut libc::c_void,
-                    user_data: *mut libc::c_void,
-                ) -> () {
-                    let wrapper = C::UserData::consume_user_data_unchecked(user_data);
-                    drop(wrapper)
-                }
-
-                sys::godot_instance_destroy_func {
-                    destroy_func: Some(destructor::<C>),
-                    method_data: ptr::null_mut(),
-                    free_func: None,
-                }
-            };
-
-            (get_api().godot_nativescript_register_class)(
-                self.handle as *mut _,
-                class_name.as_ptr() as *const _,
-                base_name.as_ptr() as *const _,
-                create,
-                destroy,
-            );
-
-            (get_api().godot_nativescript_set_type_tag)(
-                self.handle as *mut _,
-                class_name.as_ptr() as *const _,
-                crate::type_tag::create::<C>(),
-            );
-
-            let mut builder = ClassBuilder {
-                init_handle: self.handle,
-                class_name,
-                _marker: PhantomData,
-            };
-
-            C::register_properties(&mut builder);
-
-            // register methods
-            C::register(&mut builder);
-        }
+        self.add_maybe_tool_class::<C>(false)
     }
 
     /// Registers a new tool class to the engine.
     pub fn add_tool_class<C>(&self)
+    where
+        C: NativeClassMethods,
+    {
+        self.add_maybe_tool_class::<C>(true)
+    }
+
+    fn add_maybe_tool_class<C>(&self, is_tool: bool)
     where
         C: NativeClassMethods,
     {
@@ -138,7 +82,30 @@ impl InitHandle {
                     this: *mut sys::godot_object,
                     _method_data: *mut libc::c_void,
                 ) -> *mut libc::c_void {
-                    let val = C::init(C::Base::from_sys(this));
+                    use std::panic::{self, AssertUnwindSafe};
+
+                    let owner = match crate::object::godot_cast::<C::Base>(this) {
+                        Some(owner) => owner,
+                        None => {
+                            godot_error!(
+                                "gdnative-core: error constructing {}: incompatible owner type, expecting {}",
+                                C::class_name(),
+                                C::Base::class_name(),
+                            );
+                            return ptr::null_mut();
+                        }
+                    };
+
+                    let val = match panic::catch_unwind(AssertUnwindSafe(|| C::init(owner))) {
+                        Ok(val) => val,
+                        Err(_) => {
+                            godot_error!(
+                                "gdnative-core: error constructing {}: constructor panicked",
+                                C::class_name(),
+                            );
+                            return ptr::null_mut();
+                        }
+                    };
 
                     let wrapper = C::UserData::new(val);
                     C::UserData::into_user_data(wrapper) as *mut _
@@ -157,6 +124,14 @@ impl InitHandle {
                     _method_data: *mut libc::c_void,
                     user_data: *mut libc::c_void,
                 ) -> () {
+                    if user_data.is_null() {
+                        godot_error!(
+                            "gdnative-core: user data pointer for {} is null (did the constructor fail?)",
+                            C::class_name(),
+                        );
+                        return;
+                    }
+
                     let wrapper = C::UserData::consume_user_data_unchecked(user_data);
                     drop(wrapper)
                 }
@@ -168,13 +143,23 @@ impl InitHandle {
                 }
             };
 
-            (get_api().godot_nativescript_register_tool_class)(
-                self.handle as *mut _,
-                class_name.as_ptr() as *const _,
-                base_name.as_ptr() as *const _,
-                create,
-                destroy,
-            );
+            if is_tool {
+                (get_api().godot_nativescript_register_tool_class)(
+                    self.handle as *mut _,
+                    class_name.as_ptr() as *const _,
+                    base_name.as_ptr() as *const _,
+                    create,
+                    destroy,
+                );
+            } else {
+                (get_api().godot_nativescript_register_class)(
+                    self.handle as *mut _,
+                    class_name.as_ptr() as *const _,
+                    base_name.as_ptr() as *const _,
+                    create,
+                    destroy,
+                );
+            }
 
             (get_api().godot_nativescript_set_type_tag)(
                 self.handle as *mut _,

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -98,16 +98,25 @@ use std::mem;
 pub static mut GODOT_API: Option<GodotApi> = None;
 #[doc(hidden)]
 pub static mut GDNATIVE_LIBRARY_SYS: Option<*mut sys::godot_object> = None;
+
+/// Returns a reference to the current API struct.
+///
+/// This function is intended to be part of the internal API. It should only be called after
+/// `gdnative_init` and before `gdnative_terminate`. **Calling this function when the API is
+/// not bound will lead to an abort**, since in most cases there is simply no point to continue
+/// if `get_api` failed. This allows it to be used in FFI contexts without a `catch_unwind`.
 #[inline]
 #[doc(hidden)]
 pub fn get_api() -> &'static GodotApi {
-    unsafe { GODOT_API.as_ref().expect("API not bound") }
+    unsafe { GODOT_API.as_ref().unwrap_or_else(|| std::process::abort()) }
 }
+
 #[inline]
 #[doc(hidden)]
 pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
     unsafe { GDNATIVE_LIBRARY_SYS.expect("GDNativeLibrary not bound") }
 }
+
 #[inline]
 #[doc(hidden)]
 pub unsafe fn cleanup_internal_state() {


### PR DESCRIPTION
Checked all `extern "C"` declarations and modified them so that panics cannot
cross the FFI border. The following changes are made:

- Clarified that `UserData` implementations must never panic.
- Added panic guarantees about `godot_warn` and `godot_error`. This is mainly relevant for internal uses.
- `get_api()` now aborts instead of panic if the API is not bound.
- Added `catch_unwind` around constructors and property accessors.
- Added `catch_unwind` around init and terminate hooks.
- Trying to attach a NativeScript to an object with an incompatible type will produce an error message instead of UB. Trying to use said object results in further error messages instead of UB.
- Deprecated and cleared the implementations of `godot_wrap_constructor` and `godot_wrap_destructor`, old macros for low-level registration which is no longer supported.

The reproduction project from https://github.com/GodotNativeTools/godot-rust/issues/337#issuecomment-623100870 now correctly prints:

```
ERROR: <native>: gdnative-core: error constructing HelloWorld: incompatible owner type, expecting MultiMesh
ERROR: <native>: gdnative-core: user data pointer for HelloWorld is null (did the constructor fail?)
```

Close #337