### PR TITLE
Top-level hidden interface cleanup

### DIFF
--- a/bindings_generator/src/methods.rs
+++ b/bindings_generator/src/methods.rs
@@ -596,7 +596,7 @@ fn generate_return_post(w: &mut impl Write, ty: &Ty) -> GeneratorResult {
             writeln!(
                 w,
                 r#"
-    result_from_sys(ret)"#
+    GodotError::result_from_sys(ret)"#
             )?;
         }
         &Ty::Enum(_) => {

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -340,7 +340,7 @@ pub fn generate_gdnative_library_singleton_getter(
 /// See also `Instance::new` for a typed API.
 #[inline]
 pub fn current_library() -> Self {{
-    let this = get_gdnative_library_sys();
+    let this = gdnative_core::private::get_gdnative_library_sys();
 
     Self {{
         this

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use gdnative_core::*;
 
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 
 use libc;

--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::VariantArray;
 

--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -1,5 +1,5 @@
-use crate::get_api;
 use crate::object;
+use crate::private::get_api;
 use crate::sys;
 use crate::FromVariant;
 use crate::FromVariantError;
@@ -115,7 +115,7 @@ impl<T: NativeClass> Instance<T> {
                 std::ptr::null_mut(),
             );
 
-            let mut args: [*const libc::c_void; 1] = [crate::get_gdnative_library_sys()];
+            let mut args: [*const libc::c_void; 1] = [crate::private::get_gdnative_library_sys()];
             (gd_api.godot_method_bind_ptrcall)(
                 set_library,
                 native_script,

--- a/gdnative-core/src/color.rs
+++ b/gdnative-core/src/color.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use std::mem::transmute;
 

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::Color;
 use crate::VariantArray;

--- a/gdnative-core/src/dictionary.rs
+++ b/gdnative-core/src/dictionary.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
 

--- a/gdnative-core/src/error.rs
+++ b/gdnative-core/src/error.rs
@@ -1,0 +1,74 @@
+use crate::sys;
+
+/// Error codes used in various Godot APIs.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum GodotError {
+    Failed = sys::godot_error_GODOT_FAILED as u32,
+    Unavailable = sys::godot_error_GODOT_ERR_UNAVAILABLE as u32,
+    Unconfigured = sys::godot_error_GODOT_ERR_UNCONFIGURED as u32,
+    Unothorized = sys::godot_error_GODOT_ERR_UNAUTHORIZED as u32,
+    PrameterRange = sys::godot_error_GODOT_ERR_PARAMETER_RANGE_ERROR as u32,
+    OutOfMemory = sys::godot_error_GODOT_ERR_OUT_OF_MEMORY as u32,
+    FileNotFound = sys::godot_error_GODOT_ERR_FILE_NOT_FOUND as u32,
+    FileBadDrive = sys::godot_error_GODOT_ERR_FILE_BAD_DRIVE as u32,
+    FileBadPath = sys::godot_error_GODOT_ERR_FILE_BAD_PATH as u32,
+    FileNoPermission = sys::godot_error_GODOT_ERR_FILE_NO_PERMISSION as u32,
+    FileAlreadyInUse = sys::godot_error_GODOT_ERR_FILE_ALREADY_IN_USE as u32,
+    FileCantOpen = sys::godot_error_GODOT_ERR_FILE_CANT_OPEN as u32,
+    FileCantWrite = sys::godot_error_GODOT_ERR_FILE_CANT_WRITE as u32,
+    FileCantRead = sys::godot_error_GODOT_ERR_FILE_CANT_READ as u32,
+    FileUnrecognized = sys::godot_error_GODOT_ERR_FILE_UNRECOGNIZED as u32,
+    FileCorrupt = sys::godot_error_GODOT_ERR_FILE_CORRUPT as u32,
+    FileMissingDependency = sys::godot_error_GODOT_ERR_FILE_MISSING_DEPENDENCIES as u32,
+    FileEof = sys::godot_error_GODOT_ERR_FILE_EOF as u32,
+    CantOpen = sys::godot_error_GODOT_ERR_CANT_OPEN as u32,
+    CantCreate = sys::godot_error_GODOT_ERR_CANT_CREATE as u32,
+    QueryFailed = sys::godot_error_GODOT_ERR_QUERY_FAILED as u32,
+    AlreadyInUse = sys::godot_error_GODOT_ERR_ALREADY_IN_USE as u32,
+    Locked = sys::godot_error_GODOT_ERR_LOCKED as u32,
+    TimeOut = sys::godot_error_GODOT_ERR_TIMEOUT as u32,
+    CantConnect = sys::godot_error_GODOT_ERR_CANT_CONNECT as u32,
+    CantResolve = sys::godot_error_GODOT_ERR_CANT_RESOLVE as u32,
+    ConnectionError = sys::godot_error_GODOT_ERR_CONNECTION_ERROR as u32,
+    CantAcquireResource = sys::godot_error_GODOT_ERR_CANT_ACQUIRE_RESOURCE as u32,
+    CantFork = sys::godot_error_GODOT_ERR_CANT_FORK as u32,
+    InvalidData = sys::godot_error_GODOT_ERR_INVALID_DATA as u32,
+    InvalidParameter = sys::godot_error_GODOT_ERR_INVALID_PARAMETER as u32,
+    AlreadyExists = sys::godot_error_GODOT_ERR_ALREADY_EXISTS as u32,
+    DoesNotExist = sys::godot_error_GODOT_ERR_DOES_NOT_EXIST as u32,
+    DatabaseCantRead = sys::godot_error_GODOT_ERR_DATABASE_CANT_READ as u32,
+    DatabaseCantWrite = sys::godot_error_GODOT_ERR_DATABASE_CANT_WRITE as u32,
+    CompilationFailed = sys::godot_error_GODOT_ERR_COMPILATION_FAILED as u32,
+    MethodNotFound = sys::godot_error_GODOT_ERR_METHOD_NOT_FOUND as u32,
+    LinkFailed = sys::godot_error_GODOT_ERR_LINK_FAILED as u32,
+    ScriptFailed = sys::godot_error_GODOT_ERR_SCRIPT_FAILED as u32,
+    CyclicLink = sys::godot_error_GODOT_ERR_CYCLIC_LINK as u32,
+    InvalidDeclaration = sys::godot_error_GODOT_ERR_INVALID_DECLARATION as u32,
+    DuplicateSymbol = sys::godot_error_GODOT_ERR_DUPLICATE_SYMBOL as u32,
+    ParseError = sys::godot_error_GODOT_ERR_PARSE_ERROR as u32,
+    Busy = sys::godot_error_GODOT_ERR_BUSY as u32,
+    Skip = sys::godot_error_GODOT_ERR_SKIP as u32,
+    Help = sys::godot_error_GODOT_ERR_HELP as u32,
+    Bug = sys::godot_error_GODOT_ERR_BUG as u32,
+    PrinterOnFire = sys::godot_error_GODOT_ERR_PRINTER_ON_FIRE as u32,
+}
+
+impl GodotError {
+    /// Creates a `Result<(), GodotError>` from a raw error code.
+    ///
+    /// This is intended to be an internal API.
+    ///
+    /// # Safety
+    ///
+    /// `err` should be a valid value for `GodotError`.
+    #[inline]
+    #[doc(hidden)]
+    pub unsafe fn result_from_sys(err: sys::godot_error) -> Result<(), Self> {
+        if err == sys::godot_error_GODOT_OK {
+            return Ok(());
+        }
+
+        Err(std::mem::transmute(err as u32))
+    }
+}

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::VariantArray;
 

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -2,7 +2,7 @@
 #![allow(unused_imports)]
 
 use super::*;
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::sys::GodotApi;
 

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -29,7 +29,7 @@ use std::ptr;
 
 use libc;
 
-use crate::get_api;
+use crate::private::get_api;
 use crate::NativeClass;
 
 use crate::Variant;

--- a/gdnative-core/src/init/property.rs
+++ b/gdnative-core/src/init/property.rs
@@ -2,8 +2,8 @@
 
 use std::mem;
 
-use crate::get_api;
 use crate::object::GodotObject;
+use crate::private::get_api;
 use crate::GodotString;
 use crate::NativeClass;
 use crate::ToVariant;

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::VariantArray;
 

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -42,6 +42,7 @@ mod byte_array;
 mod color;
 mod color_array;
 mod dictionary;
+pub mod error;
 mod float32_array;
 mod free_on_drop;
 mod generated;
@@ -62,6 +63,10 @@ mod vector2;
 mod vector2_array;
 mod vector3;
 mod vector3_array;
+
+/// Internal low-level API for use by macros and generated bindings. Not a part of the public API.
+#[doc(hidden)]
+pub mod private;
 
 pub use crate::byte_array::*;
 pub use crate::class::*;
@@ -92,90 +97,8 @@ pub use crate::vector3_array::*;
 
 pub use sys::GodotApi;
 
-use std::mem;
-
-#[doc(hidden)]
-pub static mut GODOT_API: Option<GodotApi> = None;
-#[doc(hidden)]
-pub static mut GDNATIVE_LIBRARY_SYS: Option<*mut sys::godot_object> = None;
-
-/// Returns a reference to the current API struct.
-///
-/// This function is intended to be part of the internal API. It should only be called after
-/// `gdnative_init` and before `gdnative_terminate`. **Calling this function when the API is
-/// not bound will lead to an abort**, since in most cases there is simply no point to continue
-/// if `get_api` failed. This allows it to be used in FFI contexts without a `catch_unwind`.
-#[inline]
-#[doc(hidden)]
-pub fn get_api() -> &'static GodotApi {
-    unsafe { GODOT_API.as_ref().unwrap_or_else(|| std::process::abort()) }
-}
-
-#[inline]
-#[doc(hidden)]
-pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
-    unsafe { GDNATIVE_LIBRARY_SYS.expect("GDNativeLibrary not bound") }
-}
-
-#[inline]
-#[doc(hidden)]
-pub unsafe fn cleanup_internal_state() {
-    type_tag::cleanup();
-    GODOT_API = None;
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[repr(u32)]
-pub enum GodotError {
-    Failed = sys::godot_error_GODOT_FAILED as u32,
-    Unavailable = sys::godot_error_GODOT_ERR_UNAVAILABLE as u32,
-    Unconfigured = sys::godot_error_GODOT_ERR_UNCONFIGURED as u32,
-    Unothorized = sys::godot_error_GODOT_ERR_UNAUTHORIZED as u32,
-    PrameterRange = sys::godot_error_GODOT_ERR_PARAMETER_RANGE_ERROR as u32,
-    OutOfMemory = sys::godot_error_GODOT_ERR_OUT_OF_MEMORY as u32,
-    FileNotFound = sys::godot_error_GODOT_ERR_FILE_NOT_FOUND as u32,
-    FileBadDrive = sys::godot_error_GODOT_ERR_FILE_BAD_DRIVE as u32,
-    FileBadPath = sys::godot_error_GODOT_ERR_FILE_BAD_PATH as u32,
-    FileNoPermission = sys::godot_error_GODOT_ERR_FILE_NO_PERMISSION as u32,
-    FileAlreadyInUse = sys::godot_error_GODOT_ERR_FILE_ALREADY_IN_USE as u32,
-    FileCantOpen = sys::godot_error_GODOT_ERR_FILE_CANT_OPEN as u32,
-    FileCantWrite = sys::godot_error_GODOT_ERR_FILE_CANT_WRITE as u32,
-    FileCantRead = sys::godot_error_GODOT_ERR_FILE_CANT_READ as u32,
-    FileUnrecognized = sys::godot_error_GODOT_ERR_FILE_UNRECOGNIZED as u32,
-    FileCorrupt = sys::godot_error_GODOT_ERR_FILE_CORRUPT as u32,
-    FileMissingDependency = sys::godot_error_GODOT_ERR_FILE_MISSING_DEPENDENCIES as u32,
-    FileEof = sys::godot_error_GODOT_ERR_FILE_EOF as u32,
-    CantOpen = sys::godot_error_GODOT_ERR_CANT_OPEN as u32,
-    CantCreate = sys::godot_error_GODOT_ERR_CANT_CREATE as u32,
-    QueryFailed = sys::godot_error_GODOT_ERR_QUERY_FAILED as u32,
-    AlreadyInUse = sys::godot_error_GODOT_ERR_ALREADY_IN_USE as u32,
-    Locked = sys::godot_error_GODOT_ERR_LOCKED as u32,
-    TimeOut = sys::godot_error_GODOT_ERR_TIMEOUT as u32,
-    CantConnect = sys::godot_error_GODOT_ERR_CANT_CONNECT as u32,
-    CantResolve = sys::godot_error_GODOT_ERR_CANT_RESOLVE as u32,
-    ConnectionError = sys::godot_error_GODOT_ERR_CONNECTION_ERROR as u32,
-    CantAcquireResource = sys::godot_error_GODOT_ERR_CANT_ACQUIRE_RESOURCE as u32,
-    CantFork = sys::godot_error_GODOT_ERR_CANT_FORK as u32,
-    InvalidData = sys::godot_error_GODOT_ERR_INVALID_DATA as u32,
-    InvalidParameter = sys::godot_error_GODOT_ERR_INVALID_PARAMETER as u32,
-    AlreadyExists = sys::godot_error_GODOT_ERR_ALREADY_EXISTS as u32,
-    DoesNotExist = sys::godot_error_GODOT_ERR_DOES_NOT_EXIST as u32,
-    DatabaseCantRead = sys::godot_error_GODOT_ERR_DATABASE_CANT_READ as u32,
-    DatabaseCantWrite = sys::godot_error_GODOT_ERR_DATABASE_CANT_WRITE as u32,
-    CompilationFailed = sys::godot_error_GODOT_ERR_COMPILATION_FAILED as u32,
-    MethodNotFound = sys::godot_error_GODOT_ERR_METHOD_NOT_FOUND as u32,
-    LinkFailed = sys::godot_error_GODOT_ERR_LINK_FAILED as u32,
-    ScriptFailed = sys::godot_error_GODOT_ERR_SCRIPT_FAILED as u32,
-    CyclicLink = sys::godot_error_GODOT_ERR_CYCLIC_LINK as u32,
-    InvalidDeclaration = sys::godot_error_GODOT_ERR_INVALID_DECLARATION as u32,
-    DuplicateSymbol = sys::godot_error_GODOT_ERR_DUPLICATE_SYMBOL as u32,
-    ParseError = sys::godot_error_GODOT_ERR_PARSE_ERROR as u32,
-    Busy = sys::godot_error_GODOT_ERR_BUSY as u32,
-    Skip = sys::godot_error_GODOT_ERR_SKIP as u32,
-    Help = sys::godot_error_GODOT_ERR_HELP as u32,
-    Bug = sys::godot_error_GODOT_ERR_BUG as u32,
-    PrinterOnFire = sys::godot_error_GODOT_ERR_PRINTER_ON_FIRE as u32,
-}
+#[doc(inline)]
+pub use error::GodotError;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u32)]
@@ -187,41 +110,10 @@ pub enum Vector3Axis {
 
 pub type GodotResult = Result<(), GodotError>;
 
+#[deprecated(
+    since = "0.8.1",
+    note = "This is intended for internal use, and will be removed from the public API in 0.9"
+)]
 pub fn result_from_sys(err: sys::godot_error) -> GodotResult {
-    if err == sys::godot_error_GODOT_OK {
-        return Ok(());
-    }
-
-    Err(unsafe { mem::transmute(err as u32) })
-}
-
-pub unsafe fn report_init_error(
-    options: *const sys::godot_gdnative_init_options,
-    error: sys::InitError,
-) {
-    use std::ffi::CString;
-    match error {
-        sys::InitError::VersionMismatch {
-            api_type,
-            want,
-            got,
-        } => {
-            if let Some(f) = (*options).report_version_mismatch {
-                f(
-                    (*options).gd_native_library,
-                    CString::new(format!("{}", api_type)).unwrap().as_ptr(),
-                    want,
-                    got,
-                );
-            }
-        }
-        sys::InitError::Generic { message } => {
-            if let Some(f) = (*options).report_loading_error {
-                f(
-                    (*options).gd_native_library,
-                    CString::new(message).unwrap().as_ptr(),
-                );
-            }
-        }
-    }
+    unsafe { GodotError::result_from_sys(err) }
 }

--- a/gdnative-core/src/node_path.rs
+++ b/gdnative-core/src/node_path.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
 use std::fmt;

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -28,7 +28,7 @@ pub trait Instanciable: GodotObject {
 // This function assumes the godot_object is reference counted.
 pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;
-    let api = crate::get_api();
+    let api = crate::private::get_api();
     let addref_method = ReferenceMethodTable::unchecked_get().reference;
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut ok = false;
@@ -53,7 +53,7 @@ pub unsafe fn unref(obj: *mut sys::godot_object) -> bool {
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut last_reference = false;
     let ret_ptr = &mut last_reference as *mut bool;
-    (crate::get_api().godot_method_bind_ptrcall)(
+    (crate::private::get_api().godot_method_bind_ptrcall)(
         unref_method,
         obj,
         argument_buffer.as_mut_ptr() as *mut _,
@@ -70,7 +70,7 @@ pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
     let mut argument_buffer = [ptr::null() as *const libc::c_void; 0];
     let mut ok = false;
     let ret_ptr = &mut ok as *mut bool;
-    (crate::get_api().godot_method_bind_ptrcall)(
+    (crate::private::get_api().godot_method_bind_ptrcall)(
         init_method,
         obj,
         argument_buffer.as_mut_ptr() as *mut _,
@@ -82,7 +82,7 @@ pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
 
 pub fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
     unsafe {
-        let api = crate::get_api();
+        let api = crate::private::get_api();
         let method_bind = ObjectMethodTable::get(api).is_class;
 
         let mut class_name = (api.godot_string_chars_to_utf8_with_len)(

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -1,0 +1,97 @@
+use std::ffi::CString;
+
+use crate::sys;
+
+static mut GODOT_API: Option<sys::GodotApi> = None;
+static mut GDNATIVE_LIBRARY_SYS: Option<*mut sys::godot_object> = None;
+
+/// Binds the API struct from `gdnative_init_options`. Returns `true` on success.
+///
+/// This is intended to be an internal interface.
+#[inline]
+pub unsafe fn bind_api(options: *mut sys::godot_gdnative_init_options) -> bool {
+    let api = match sys::GodotApi::from_raw((*options).api_struct) {
+        Ok(api) => api,
+        Err(e) => {
+            report_init_error(options, e);
+            return false;
+        }
+    };
+
+    GODOT_API = Some(api);
+    GDNATIVE_LIBRARY_SYS = Some((*options).gd_native_library);
+
+    // Force the initialization of the method table of common types. This way we can
+    // assume that if the api object is alive we can fetch the method of these types
+    // without checking for initialization.
+    crate::ReferenceMethodTable::get(get_api());
+
+    true
+}
+
+/// Returns a reference to the current API struct.
+///
+/// This function is intended to be part of the internal API. It should only be called after
+/// `gdnative_init` and before `gdnative_terminate`. **Calling this function when the API is
+/// not bound will lead to an abort**, since in most cases there is simply no point to continue
+/// if `get_api` failed. This allows it to be used in FFI contexts without a `catch_unwind`.
+#[inline]
+pub fn get_api() -> &'static sys::GodotApi {
+    unsafe { GODOT_API.as_ref().unwrap_or_else(|| std::process::abort()) }
+}
+
+/// Returns whether the API is bound.
+///
+/// This is intended to be an internal interface.
+#[inline]
+pub fn is_api_bound() -> bool {
+    unsafe { GODOT_API.is_some() }
+}
+
+/// Returns a pointer to the `GDNativeLibrary` object for the current library.
+///
+/// This is intended to be an internal interface.
+#[inline]
+pub fn get_gdnative_library_sys() -> *mut sys::godot_object {
+    unsafe { GDNATIVE_LIBRARY_SYS.expect("GDNativeLibrary not bound") }
+}
+
+/// Performs library-wide cleanup during `terminate`.
+///
+/// This is intended to be an internal interface.
+#[inline]
+pub unsafe fn cleanup_internal_state() {
+    crate::type_tag::cleanup();
+    GODOT_API = None;
+}
+
+/// Reports an `InitError` to Godot.
+unsafe fn report_init_error(
+    options: *const sys::godot_gdnative_init_options,
+    error: sys::InitError,
+) {
+    match error {
+        sys::InitError::VersionMismatch {
+            api_type,
+            want,
+            got,
+        } => {
+            if let Some(f) = (*options).report_version_mismatch {
+                f(
+                    (*options).gd_native_library,
+                    CString::new(format!("{}", api_type)).unwrap().as_ptr(),
+                    want,
+                    got,
+                );
+            }
+        }
+        sys::InitError::Generic { message } => {
+            if let Some(f) = (*options).report_loading_error {
+                f(
+                    (*options).gd_native_library,
+                    CString::new(message).unwrap().as_ptr(),
+                );
+            }
+        }
+    }
+}

--- a/gdnative-core/src/rid.rs
+++ b/gdnative-core/src/rid.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use std::cmp::Ordering;
 use std::cmp::{Eq, PartialEq};

--- a/gdnative-core/src/string.rs
+++ b/gdnative-core/src/string.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 
 use std::cmp::Ordering;

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::GodotString;
 use crate::VariantArray;

--- a/gdnative-core/src/variant.rs
+++ b/gdnative-core/src/variant.rs
@@ -3,6 +3,8 @@ use std::default::Default;
 use std::fmt;
 use std::mem::{forget, transmute};
 
+use crate::private::get_api;
+
 // TODO: implement Debug, PartialEq, etc.
 
 /// A `Variant` can represent many of godot's core types.

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -1,4 +1,4 @@
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 
 use crate::Variant;

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -83,7 +83,7 @@ godot_test!(
 
         fn test(vector: Vector2, set_to: Vector2) {
             use crate::FromVariant;
-            let api = crate::get_api();
+            let api = crate::private::get_api();
 
             let copied = vector;
             unsafe {

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::VariantArray;
 use crate::Vector2;

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -3,7 +3,7 @@ godot_test!(
         use crate::{FromVariant, ToVariant, Vector3};
 
         fn test(vector: Vector3, set_to: Vector3) {
-            let api = crate::get_api();
+            let api = crate::private::get_api();
 
             let copied = vector;
             unsafe {

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -1,5 +1,5 @@
 use crate::access::{Aligned, MaybeUnaligned};
-use crate::get_api;
+use crate::private::get_api;
 use crate::sys;
 use crate::VariantArray;
 use crate::Vector3;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,5 +1,7 @@
 use gdnative::*;
 
+use gdnative::private::get_api;
+
 mod test_derive;
 mod test_free_ub;
 mod test_register;


### PR DESCRIPTION
- Deprecated top-level `result_from_sys`. Replaced by a hidden method.
- Made unreleased `report_init_error` private.
- Made `GODOT_API` and `GDNATIVE_LIBRARY_SYS` private.
- Moved `get_api`, `get_gdnative_library_sys` and `cleanup_internal_state` under `private`.
- Moved API initialization from `godot_gdnative_init` macro to `private::bind_api`.

Part of #357