### PR TITLE
Deprecate public items that will be removed

### DIFF
--- a/gdnative-core/src/free_on_drop.rs
+++ b/gdnative-core/src/free_on_drop.rs
@@ -1,17 +1,16 @@
+#![allow(deprecated)]
+
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
-/// Manually managed Godot classes implementing `free`.
-pub trait Free {
-    unsafe fn godot_free(self);
-}
-
-/// Manually managed Godot classes implementing `queue_free`.
-pub trait QueueFree {
-    unsafe fn godot_queue_free(&mut self);
-}
+#[doc(inline)]
+pub use crate::object::{Free, QueueFree};
 
 /// A wrapper that automatically frees the object when dropped.
+#[deprecated(
+    since = "0.8.1",
+    note = "Use of free-on-drop wrappers is no longer recommended due to upcoming changes in ownership semantics in 0.9. Call free manually instead. This will be removed in 0.9"
+)]
 pub struct FreeOnDrop<T: Free + Clone> {
     ptr: T,
 }
@@ -63,6 +62,10 @@ where
 }
 
 /// A wrapper that automatically enqueues the object for deletion when dropped.
+#[deprecated(
+    since = "0.8.1",
+    note = "Use of free-on-drop wrappers is no longer recommended due to upcoming changes in ownership semantics in 0.9. Call queue_free manually instead. This will be removed in 0.9"
+)]
 pub struct QueueFreeOnDrop<T: QueueFree + Clone> {
     ptr: T,
 }

--- a/gdnative-core/src/init.rs
+++ b/gdnative-core/src/init.rs
@@ -189,9 +189,17 @@ pub type ScriptMethodFn = unsafe extern "C" fn(
     *mut *mut sys::godot_variant,
 ) -> sys::godot_variant;
 
+#[deprecated(
+    since = "0.8.1",
+    note = "This type isn't used in the API anymore. It will be removed in 0.9"
+)]
 pub type ScriptConstructorFn =
     unsafe extern "C" fn(*mut sys::godot_object, *mut libc::c_void) -> *mut libc::c_void;
 
+#[deprecated(
+    since = "0.8.1",
+    note = "This type isn't used in the API anymore. It will be removed in 0.9"
+)]
 pub type ScriptDestructorFn =
     unsafe extern "C" fn(*mut sys::godot_object, *mut libc::c_void, *mut libc::c_void) -> ();
 
@@ -216,6 +224,11 @@ pub struct ScriptMethod<'l> {
     pub free_func: Option<unsafe extern "C" fn(*mut libc::c_void) -> ()>,
 }
 
+#[deprecated(
+    since = "0.8.1",
+    note = "This type isn't used in the API anymore. It will be removed in 0.9"
+)]
+#[allow(deprecated)]
 pub struct ClassDescriptor<'l> {
     pub name: &'l str,
     pub base_class: &'l str,

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -25,6 +25,16 @@ pub trait Instanciable: GodotObject {
     fn construct() -> Self;
 }
 
+/// Manually managed Godot classes implementing `free`.
+pub trait Free {
+    unsafe fn godot_free(self);
+}
+
+/// Manually managed Godot classes implementing `queue_free`.
+pub trait QueueFree {
+    unsafe fn godot_queue_free(&mut self);
+}
+
 // This function assumes the godot_object is reference counted.
 pub unsafe fn add_ref(obj: *mut sys::godot_object) {
     use crate::ReferenceMethodTable;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -63,8 +63,9 @@ fn test_constructor() -> bool {
     let _ = lib.is_singleton();
 
     unsafe {
-        let path = FreeOnDrop::new(Path2D::new());
+        let path = Path2D::new();
         let _ = path.get_z_index();
+        path.free();
     }
 
     return true;


### PR DESCRIPTION
## Low-level class registration types

These are simply no longer used in the codebase.

## Free-on-drop wrappers

`FreeOnDrop` and `QueueFreeOnDrop` no longer make sense under the new ownership semantic (#301) where non-reference-counted Godot objects are essentially treated as raw pointers. Users are suggested to call `free` or `queue_free` manually instead.

The `Free` and `QueueFree` traits are kept, but moved to `object` since they have possible uses as bounds outside the wrappers, and are similar to `Object::Instanciable`.
