### PR TITLE
Semi-seal the GodotObject trait.

### DIFF
--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -86,6 +86,8 @@ pub fn generate_godot_object_impl(output: &mut impl Write, class: &GodotClass) -
     writeln!(
         output,
         r#"
+impl crate::private::godot_object::Sealed for {name} {{}}
+
 unsafe impl GodotObject for {name} {{
     fn class_name() -> &'static str {{
         "{name}"

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -3,8 +3,14 @@ use crate::ObjectMethodTable;
 use libc;
 use std::ptr;
 
-/// Internal details.
-pub unsafe trait GodotObject {
+/// Trait for Godot API objects. This trait is sealed, and implemented for generated wrapper
+/// types.
+///
+/// # Remarks
+///
+/// The `cast` method on Godot object types is only for conversion between engine types.
+/// To downcast a `NativeScript` type from its base type, see `Instance::try_from_base`.
+pub unsafe trait GodotObject: crate::private::godot_object::Sealed {
     fn class_name() -> &'static str;
     #[doc(hidden)]
     unsafe fn to_sys(&self) -> *mut sys::godot_object;

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -95,3 +95,7 @@ unsafe fn report_init_error(
         }
     }
 }
+
+pub mod godot_object {
+    pub trait Sealed {}
+}


### PR DESCRIPTION
Added a `Sealed` supertrait in `gdnative_core::private` for `GodotObject`. This supertrait is actually possible to name from outside, in order to enable binding generation in `gdnative-bindings`. Its path and name should be sufficient to indicate that it should not be implemented by users.

This is not considered a breaking change, since the methods of `GodotObject` are already `#[doc(hidden)]`, excluding outside implementation using only the public API.

Part of #357