### PR TITLE
Add the claim method to GodotObject

### DIFF
--- a/gdnative-core/src/class.rs
+++ b/gdnative-core/src/class.rs
@@ -245,8 +245,7 @@ impl<T: NativeClass> Instance<T> {
         T::UserData: Map,
         F: FnOnce(&T, T::Base) -> U,
     {
-        self.script
-            .map(|script| op(script, T::Base::from_sys(self.owner.to_sys())))
+        self.script.map(|script| op(script, self.owner.claim()))
     }
 
     /// Calls a function with a NativeClass instance and its owner, and returns its return
@@ -267,8 +266,7 @@ impl<T: NativeClass> Instance<T> {
         T::UserData: MapMut,
         F: FnOnce(&mut T, T::Base) -> U,
     {
-        self.script
-            .map_mut(|script| op(script, T::Base::from_sys(self.owner.to_sys())))
+        self.script.map_mut(|script| op(script, self.owner.claim()))
     }
 
     #[doc(hidden)]

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -18,6 +18,25 @@ pub unsafe trait GodotObject {
     /// ptrcalls are leaked in the process of being cast into a pointer.
     #[doc(hidden)]
     unsafe fn from_return_position_sys(obj: *mut sys::godot_object) -> Self;
+
+    /// Creates a wrapper around the same Godot object that has `'static` lifetime.
+    ///
+    /// Most Godot APIs expect object arguments with `'static` lifetime. This method may be used
+    /// to produce a `'static` wrapper given a reference. For reference-counted types, or classes
+    /// that extend `Reference`, this increments the reference count. For manually-managed types,
+    /// including all classes that inherit `Node`, this creates an alias.
+    ///
+    /// # Remarks
+    ///
+    /// Although manually-managed types are already `unsafe` to use, like raw pointers, this is
+    /// `unsafe` because some methods expect `&mut self` receivers. In `0.9.0`, all methods will
+    /// take shared references instead, making this safe to call.
+    unsafe fn claim(&self) -> Self
+    where
+        Self: Sized,
+    {
+        Self::from_sys(self.to_sys())
+    }
 }
 
 /// GodotObjects that have a zero argument constructor.


### PR DESCRIPTION
`claim` is a public method that encapsulates the `from_sys(to_sys())` "idiom" for aliasing, which relied on hidden internal APIs. The method is `unsafe` in 0.8.1, and will be made safe in 0.9.0.

Aliasing is often required when writing code dealing with manually-managed types, since API and NativeScript methods expect "owned" versions of Godot objects. This makes aliasing part of the public API, so users won't have to call hidden public items.

# Unresolved questions

The method is named `claim` because it "claims" a `'static` version of the wrapper. Alternative names that were considered include:

- `alias`: This doesn't cover reference-counted types, but could work if a new `Alias` trait is created. However, using `Alias` as a trait bound will break compatibility of `Instance::map_aliased` and `Instance::map_mut_aliased`. An `Alias` trait can be created alongside `claim` in 0.9.0
- `owned`: This is technically correct, but is confusing because manually-managed Godot types aren't really "owned" in the Rust sense.