### PR TITLE
 #364: Adding Debug for Core array types

### DIFF
--- a/gdnative-core/src/byte_array.rs
+++ b/gdnative-core/src/byte_array.rs
@@ -3,6 +3,8 @@ use crate::get_api;
 use crate::sys;
 use crate::VariantArray;
 
+use std::fmt;
+
 /// A reference-counted vector of bytes that uses Godot's pool allocator.
 pub struct ByteArray(pub(crate) sys::godot_pool_byte_array);
 
@@ -116,6 +118,12 @@ impl ByteArray {
     }
 }
 
+impl fmt::Debug for ByteArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for ByteArray as godot_pool_byte_array {
         Drop => godot_pool_byte_array_destroy;
@@ -171,5 +179,16 @@ godot_test!(
 
         // the write shouldn't have affected the original array
         assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_byte_array_debug {
+        let mut arr = ByteArray::new();
+        for i in 0..8 {
+            arr.push(i);
+        }
+
+        assert_eq!(format!("{:?}", arr), "[0, 1, 2, 3, 4, 5, 6, 7]");
     }
 );

--- a/gdnative-core/src/color_array.rs
+++ b/gdnative-core/src/color_array.rs
@@ -4,6 +4,7 @@ use crate::sys;
 use crate::Color;
 use crate::VariantArray;
 
+use std::fmt;
 use std::mem::transmute;
 
 /// A reference-counted vector of `ColorArray` that uses Godot's pool allocator.
@@ -120,6 +121,12 @@ impl ColorArray {
     }
 }
 
+impl fmt::Debug for ColorArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for ColorArray as godot_pool_color_array {
         Drop => godot_pool_color_array_destroy;
@@ -183,5 +190,16 @@ godot_test!(
             Color::rgb(0.0, 1.0, 0.0),
             Color::rgb(0.0, 0.0, 1.0),
         ], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_color_array_debug {
+        let mut arr = ColorArray::new();
+        arr.push(&Color::rgb(1.0, 0.0, 0.0));
+        arr.push(&Color::rgb(0.0, 1.0, 0.0));
+        arr.push(&Color::rgb(0.0, 0.0, 1.0));
+
+        assert_eq!(format!("{:?}", arr), "[Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 }, Color { r: 0.0, g: 1.0, b: 0.0, a: 1.0 }, Color { r: 0.0, g: 0.0, b: 1.0, a: 1.0 }]");
     }
 );

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -3,6 +3,8 @@ use crate::get_api;
 use crate::sys;
 use crate::VariantArray;
 
+use std::fmt;
+
 /// A reference-counted vector of `f32` that uses Godot's pool allocator.
 pub struct Float32Array(pub(crate) sys::godot_pool_real_array);
 
@@ -116,6 +118,12 @@ impl Float32Array {
     }
 }
 
+impl fmt::Debug for Float32Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for Float32Array as godot_pool_real_array {
         Drop => godot_pool_real_array_destroy;
@@ -171,5 +179,16 @@ godot_test!(
 
         // the write shouldn't have affected the original array
         assert_eq!(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_float32_array_debug {
+        let mut arr = Float32Array::new();
+        for i in 0..8 {
+            arr.push(i as f32);
+        }
+
+        assert_eq!(format!("{:?}", arr), "[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]");
     }
 );

--- a/gdnative-core/src/int32_array.rs
+++ b/gdnative-core/src/int32_array.rs
@@ -3,6 +3,8 @@ use crate::get_api;
 use crate::sys;
 use crate::VariantArray;
 
+use std::fmt;
+
 /// A reference-counted vector of `i32` that uses Godot's pool allocator.
 pub struct Int32Array(pub(crate) sys::godot_pool_int_array);
 
@@ -116,6 +118,12 @@ impl Int32Array {
     }
 }
 
+impl fmt::Debug for Int32Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for Int32Array as godot_pool_int_array {
         Drop => godot_pool_int_array_destroy;
@@ -171,5 +179,15 @@ godot_test!(
 
         // the write shouldn't have affected the original array
         assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_int32_array_debug {
+        let mut arr = Int32Array::new();
+        for i in 0..8 {
+            arr.push(i);
+        }
+        assert_eq!(format!("{:?}", arr), "[0, 1, 2, 3, 4, 5, 6, 7]");
     }
 );

--- a/gdnative-core/src/string_array.rs
+++ b/gdnative-core/src/string_array.rs
@@ -4,6 +4,8 @@ use crate::sys;
 use crate::GodotString;
 use crate::VariantArray;
 
+use std::fmt;
+
 /// A vector of `GodotString` that uses Godot's pool allocator.
 pub struct StringArray(pub(crate) sys::godot_pool_string_array);
 
@@ -117,6 +119,12 @@ impl StringArray {
     }
 }
 
+impl fmt::Debug for StringArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for StringArray as godot_pool_string_array {
         Drop => godot_pool_string_array_destroy;
@@ -180,5 +188,16 @@ godot_test!(
             GodotString::from("bar"),
             GodotString::from("baz"),
         ], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_string_array_debug {
+        let mut arr = StringArray::new();
+        arr.push(&GodotString::from("foo"));
+        arr.push(&GodotString::from("bar"));
+        arr.push(&GodotString::from("baz"));
+
+        assert_eq!(format!("{:?}", arr), "[\"foo\", \"bar\", \"baz\"]");
     }
 );

--- a/gdnative-core/src/variant_array.rs
+++ b/gdnative-core/src/variant_array.rs
@@ -3,6 +3,8 @@ use crate::sys;
 
 use crate::Variant;
 
+use std::fmt;
+
 /// A reference-counted `Variant` vector. Godot's generic array data type.
 /// Negative indices can be used to count from the right.
 pub struct VariantArray(pub(crate) sys::godot_array);
@@ -186,6 +188,12 @@ impl_basic_traits!(
     }
 );
 
+impl fmt::Debug for VariantArray {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 pub struct Iter<'a> {
     arr: &'a VariantArray,
     range: std::ops::Range<i32>,
@@ -302,6 +310,17 @@ godot_test!(test_array {
         array3.iter().map(|v| v.try_to_i64().unwrap()).collect::<Vec<_>>().as_slice(),
     );
 });
+
+godot_test!(
+    test_array_debug {
+        let mut arr = VariantArray::new(); // []
+        arr.push(&Variant::from_str("hello world"));
+        arr.push(&Variant::from_bool(true));
+        arr.push(&Variant::from_i64(42));
+
+        assert_eq!(format!("{:?}", arr), "[GodotString(hello world), Bool(True), I64(42)]");
+    }
+);
 
 // TODO: clear arrays without affecting clones
 //godot_test!(test_array_clone_clear {

--- a/gdnative-core/src/vector2_array.rs
+++ b/gdnative-core/src/vector2_array.rs
@@ -4,6 +4,7 @@ use crate::sys;
 use crate::VariantArray;
 use crate::Vector2;
 
+use std::fmt;
 use std::mem::transmute;
 
 /// A reference-counted vector of `Vector2` that uses Godot's pool allocator.
@@ -120,6 +121,12 @@ impl Vector2Array {
     }
 }
 
+impl fmt::Debug for Vector2Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for Vector2Array as godot_pool_vector2_array {
         Drop => godot_pool_vector2_array_destroy;
@@ -183,5 +190,16 @@ godot_test!(
             Vector2::new(3.0, 4.0),
             Vector2::new(5.0, 6.0),
         ], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_vector2_array_debug {
+        let mut arr = Vector2Array::new();
+        arr.push(&Vector2::new(1.0, 2.0));
+        arr.push(&Vector2::new(3.0, 4.0));
+        arr.push(&Vector2::new(5.0, 6.0));
+
+        assert_eq!(format!("{:?}", arr), "[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]");
     }
 );

--- a/gdnative-core/src/vector3_array.rs
+++ b/gdnative-core/src/vector3_array.rs
@@ -4,6 +4,7 @@ use crate::sys;
 use crate::VariantArray;
 use crate::Vector3;
 
+use std::fmt;
 use std::mem::transmute;
 
 /// A reference-counted vector of `Vector3` that uses Godot's pool allocator.
@@ -120,6 +121,12 @@ impl Vector3Array {
     }
 }
 
+impl fmt::Debug for Vector3Array {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.read().iter()).finish()
+    }
+}
+
 impl_basic_traits!(
     for Vector3Array as godot_pool_vector3_array {
         Drop => godot_pool_vector3_array_destroy;
@@ -184,5 +191,16 @@ godot_test!(
             Vector3::new(3.0, 4.0, 5.0),
             Vector3::new(5.0, 6.0, 7.0),
         ], original_read.as_slice());
+    }
+);
+
+godot_test!(
+    test_vector3_array_debug {
+        let mut arr = Vector3Array::new();
+        arr.push(&Vector3::new(1.0, 2.0, 3.0));
+        arr.push(&Vector3::new(3.0, 4.0, 5.0));
+        arr.push(&Vector3::new(5.0, 6.0, 7.0));
+
+        assert_eq!(format!("{:?}", arr), "[(1.0, 2.0, 3.0), (3.0, 4.0, 5.0), (5.0, 6.0, 7.0)]");
     }
 );

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -18,6 +18,7 @@ pub extern "C" fn run_tests(
     // status &= gdnative::test_dictionary_clone_clear();
 
     status &= gdnative::test_array();
+    status &= gdnative::test_array_debug();
     // status &= gdnative::test_array_clone_clear();
 
     status &= gdnative::test_variant_nil();
@@ -34,12 +35,19 @@ pub extern "C" fn run_tests(
     status &= gdnative::test_variant_tuple();
 
     status &= gdnative::test_byte_array_access();
+    status &= gdnative::test_byte_array_debug();
     status &= gdnative::test_int32_array_access();
+    status &= gdnative::test_int32_array_debug();
     status &= gdnative::test_float32_array_access();
+    status &= gdnative::test_float32_array_debug();
     status &= gdnative::test_color_array_access();
+    status &= gdnative::test_color_array_debug();
     status &= gdnative::test_string_array_access();
+    status &= gdnative::test_string_array_debug();
     status &= gdnative::test_vector2_array_access();
+    status &= gdnative::test_vector2_array_debug();
     status &= gdnative::test_vector3_array_access();
+    status &= gdnative::test_vector3_array_debug();
 
     status &= test_constructor();
     status &= test_underscore_method_binding();


### PR DESCRIPTION
Most Debug impl were done using self.read().iter()
Only VariantArray was different, using self.iter()