### PR TITLE
Add clippy to CI, fix clippy correctness lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ matrix:
       before_script:
        - rustup component add rustfmt
 
+    - name: cargo clippy (stable)
+      os: linux
+      rust: stable
+      env: CI_STAGE_CARGO_CLIPPY=yes
+      before_script:
+       - rustup component add clippy
+
     - name: cargo test (stable)
       os: linux
       rust: stable
@@ -37,6 +44,13 @@ matrix:
       os: linux
       rust: nightly
       env: CI_STAGE_CARGO_TEST=yes
+
+    - name: cargo clippy (nightly)
+      os: linux
+      rust: nightly
+      env: CI_STAGE_CARGO_CLIPPY=yes
+      before_script:
+       - rustup component add clippy
 
     - name: cargo build --release (nightly)
       os: linux
@@ -95,6 +109,10 @@ script:
       cd ..;
       cd gdnative-sys;
       cargo dinghy --platform auto-ios-x86_64 test;
+    fi
+
+  - if [[ "$CI_STAGE_CARGO_CLIPPY" == "yes" ]]; then
+      cargo clippy --all --all-features;
     fi
 
   - if [[ "$CI_STAGE_CARGO_TEST" == "yes" ]]; then

--- a/bindings_generator/src/api.rs
+++ b/bindings_generator/src/api.rs
@@ -1,4 +1,3 @@
-use serde_json;
 use std::collections::{HashMap, HashSet};
 
 pub struct Api {

--- a/bindings_generator/src/special_methods.rs
+++ b/bindings_generator/src/special_methods.rs
@@ -204,7 +204,9 @@ pub fn generate_dynamic_cast(output: &mut impl Write, class: &GodotClass) -> Gen
         r#"
     /// Generic dynamic cast.
     pub {maybe_unsafe}fn cast<T: GodotObject>(&self) -> Option<T> {{
-        object::godot_cast::<T>(self.this)
+    unsafe {{
+            object::godot_cast::<T>(self.this)
+        }}
     }}"#,
         maybe_unsafe = if class.is_pointer_safe() {
             ""

--- a/gdnative-bindings/src/lib.rs
+++ b/gdnative-bindings/src/lib.rs
@@ -1,5 +1,10 @@
 #![allow(non_snake_case)] // because of the generated bindings.
 #![allow(unused_imports)]
+#![allow(unused_unsafe)]
+// False positives on generated drops that enforce lifetime
+#![allow(clippy::drop_copy)]
+// Disable non-critical lints for generated code.
+#![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 pub use gdnative_core::*;
 

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -10,7 +10,7 @@ workspace = ".."
 edition = "2018"
 
 [features]
-gd_test = []
+gd_test = ["approx"]
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "0.8.0" }
@@ -18,6 +18,9 @@ libc = "0.2"
 bitflags = "1.2"
 euclid = "0.20.1"
 parking_lot = "0.9.0"
+
+# Used for float comparisons in godot tests
+approx = { version = "0.3.2", optional = true }
 
 [build-dependencies]
 gdnative_bindings_generator = { path = "../bindings_generator", version = "0.8.0" }

--- a/gdnative-core/src/access.rs
+++ b/gdnative-core/src/access.rs
@@ -219,6 +219,9 @@ mod tests {
     fn it_detects_unaligned_ptrs() {
         let vec: Vec<i64> = vec![1, 2, 3, 4, 5, 6, 7, 8];
         let aligned = vec.as_ptr();
+
+        // That's exactly what's being tested here. Thanks clippy!
+        #[allow(clippy::cast_ptr_alignment)]
         let unaligned = unsafe { (aligned as *const u8).add(1) as *const i64 };
 
         assert_eq!(
@@ -243,6 +246,8 @@ mod tests {
     fn it_can_copy_back_owned() {
         let mut arr: [u8; 512] = [0; 512];
 
+        // That's exactly what's being tested here. Thanks clippy!
+        #[allow(clippy::cast_ptr_alignment)]
         let unaligned_ptr = unsafe {
             let mut ptr = &mut arr[0] as *mut u8;
             for _ in 0..(512 - 64) {

--- a/gdnative-core/src/float32_array.rs
+++ b/gdnative-core/src/float32_array.rs
@@ -159,7 +159,9 @@ godot_test!(
 
         let original_read = {
             let read = arr.read();
-            assert_eq!(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], read.as_slice());
+            for (n, i) in read.as_slice().iter().enumerate() {
+                assert_relative_eq!(n as f32, i);
+            }
             read.clone()
         };
 
@@ -174,11 +176,13 @@ godot_test!(
         }
 
         for i in 0..8 {
-            assert_eq!(i as f32 * 2.0, cow_arr.get(i as i32));
+            assert_relative_eq!(i as f32 * 2., cow_arr.get(i as i32));
         }
 
         // the write shouldn't have affected the original array
-        assert_eq!(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0], original_read.as_slice());
+        for (n, i) in original_read.as_slice().iter().enumerate() {
+            assert_relative_eq!(n as f32, i);
+        }
     }
 );
 

--- a/gdnative-core/src/generated.rs
+++ b/gdnative-core/src/generated.rs
@@ -1,5 +1,11 @@
 #![allow(non_snake_case)] // because of the generated bindings.
 #![allow(unused_imports)]
+#![allow(unused_unsafe)]
+
+// False positives on generated drops that enforce lifetime
+#![allow(clippy::drop_copy)]
+// Disable non-critical lints for generated code.
+#![allow(clippy::style, clippy::complexity, clippy::perf)]
 
 use super::*;
 use crate::private::get_api;

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -24,6 +24,9 @@
 //! engine or the object must be carefully deallocated using the object's `free`  method.
 //!
 
+#![allow(clippy::transmute_ptr_to_ptr)]
+#![cfg_attr(feature = "gd_test", allow(clippy::blacklisted_name))]
+
 #[doc(hidden)]
 pub extern crate gdnative_sys as sys;
 #[doc(hidden)]
@@ -31,6 +34,10 @@ pub extern crate libc;
 #[macro_use]
 extern crate bitflags;
 extern crate parking_lot;
+
+#[cfg(feature = "gd_test")]
+#[macro_use]
+extern crate approx;
 
 pub mod geom;
 

--- a/gdnative-core/src/object.rs
+++ b/gdnative-core/src/object.rs
@@ -115,43 +115,39 @@ pub unsafe fn init_ref_count(obj: *mut sys::godot_object) {
     debug_assert!(ok);
 }
 
-pub fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
-    unsafe {
-        let api = crate::private::get_api();
-        let method_bind = ObjectMethodTable::get(api).is_class;
+pub unsafe fn is_class(obj: *mut sys::godot_object, class_name: &str) -> bool {
+    let api = crate::private::get_api();
+    let method_bind = ObjectMethodTable::get(api).is_class;
 
-        let mut class_name = (api.godot_string_chars_to_utf8_with_len)(
-            class_name.as_ptr() as *const _,
-            class_name.len() as _,
-        );
+    let mut class_name = (api.godot_string_chars_to_utf8_with_len)(
+        class_name.as_ptr() as *const _,
+        class_name.len() as _,
+    );
 
-        let mut argument_buffer = [ptr::null() as *const libc::c_void; 1];
-        argument_buffer[0] = (&class_name) as *const _ as *const _;
+    let mut argument_buffer = [ptr::null() as *const libc::c_void; 1];
+    argument_buffer[0] = (&class_name) as *const _ as *const _;
 
-        let mut ret = false;
-        let ret_ptr = &mut ret as *mut _;
-        (api.godot_method_bind_ptrcall)(
-            method_bind,
-            obj,
-            argument_buffer.as_mut_ptr() as *mut _,
-            ret_ptr as *mut _,
-        );
+    let mut ret = false;
+    let ret_ptr = &mut ret as *mut _;
+    (api.godot_method_bind_ptrcall)(
+        method_bind,
+        obj,
+        argument_buffer.as_mut_ptr() as *mut _,
+        ret_ptr as *mut _,
+    );
 
-        (api.godot_string_destroy)(&mut class_name);
+    (api.godot_string_destroy)(&mut class_name);
 
-        ret
-    }
+    ret
 }
 
-pub fn godot_cast<T>(from: *mut sys::godot_object) -> Option<T>
+pub unsafe fn godot_cast<T>(from: *mut sys::godot_object) -> Option<T>
 where
     T: GodotObject,
 {
-    unsafe {
-        if !is_class(from, T::class_name()) {
-            return None;
-        }
-
-        Some(T::from_sys(from))
+    if !is_class(from, T::class_name()) {
+        return None;
     }
+
+    Some(T::from_sys(from))
 }

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -77,20 +77,14 @@ unsafe fn report_init_error(
             got,
         } => {
             if let Some(f) = (*options).report_version_mismatch {
-                f(
-                    (*options).gd_native_library,
-                    CString::new(format!("{}", api_type)).unwrap().as_ptr(),
-                    want,
-                    got,
-                );
+                let message = CString::new(format!("{}", api_type)).unwrap();
+                f((*options).gd_native_library, message.as_ptr(), want, got);
             }
         }
         sys::InitError::Generic { message } => {
             if let Some(f) = (*options).report_loading_error {
-                f(
-                    (*options).gd_native_library,
-                    CString::new(message).unwrap().as_ptr(),
-                );
+                let message = CString::new(message).unwrap();
+                f((*options).gd_native_library, message.as_ptr());
             }
         }
     }

--- a/gdnative-core/src/vector2.rs
+++ b/gdnative-core/src/vector2.rs
@@ -87,8 +87,14 @@ godot_test!(
 
             let copied = vector;
             unsafe {
-                assert_eq!(vector.x, (api.godot_vector2_get_x)(&copied as *const _ as *const sys::godot_vector2));
-                assert_eq!(vector.y, (api.godot_vector2_get_y)(&copied as *const _ as *const sys::godot_vector2));
+                assert_relative_eq!(
+                    vector.x,
+                    (api.godot_vector2_get_x)(&copied as *const _ as *const sys::godot_vector2),
+                );
+                assert_relative_eq!(
+                    vector.y,
+                    (api.godot_vector2_get_y)(&copied as *const _ as *const sys::godot_vector2),
+                );
             }
             assert_eq!(vector, copied);
 

--- a/gdnative-core/src/vector3.rs
+++ b/gdnative-core/src/vector3.rs
@@ -7,15 +7,15 @@ godot_test!(
 
             let copied = vector;
             unsafe {
-                assert_eq!(vector.x, (api.godot_vector3_get_axis)(
+                assert_relative_eq!(vector.x, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
                     crate::Vector3Axis::X as u32 as sys::godot_vector3_axis
                 ));
-                assert_eq!(vector.y, (api.godot_vector3_get_axis)(
+                assert_relative_eq!(vector.y, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
                     crate::Vector3Axis::Y as u32 as sys::godot_vector3_axis
                 ));
-                assert_eq!(vector.z, (api.godot_vector3_get_axis)(
+                assert_relative_eq!(vector.z, (api.godot_vector3_get_axis)(
                     &copied as *const _ as *const sys::godot_vector3,
                     crate::Vector3Axis::Z as u32 as sys::godot_vector3_axis
                 ));

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::blacklisted_name)]
+
 use gdnative::*;
 
 use gdnative::private::get_api;
@@ -200,6 +202,7 @@ impl OptionalArgs {
 #[methods]
 impl OptionalArgs {
     #[export]
+    #[allow(clippy::many_single_char_names)]
     fn opt_sum(
         &self,
         _owner: Reference,


### PR DESCRIPTION
This only fails on `deny` lints currently. Although some warnings on generated code have been silenced (to keep Travis from erroring out from all the text), there are still quite a lot in the code that should be fixed / silenced eventually.

## Changes made

- Use `approx` for float equality in several tests.
- Fix dangling CString pointer in `private::report_init_error`.
- Add `unsafe` to `object::is_class` and `object::godot_cast`.
- Add `unsafe` to entry points generated by `init` and `terminate` macros.
- Allow intentional `cast_ptr_alignment` in access tests.
- Allow `drop_copy` and non-correctness lints in generated bindings.
- Allow `blacklisted_name` (e.g. `foo`) in godot tests.

Partly address #204