### PR TITLE
Add Aether<T>, a special UserData wrapper for ZSTs

### DIFF
--- a/test/src/test_register.rs
+++ b/test/src/test_register.rs
@@ -13,11 +13,12 @@ pub(crate) fn register(handle: &init::InitHandle) {
     handle.add_class::<RegisterProperty>();
 }
 
+#[derive(Copy, Clone, Debug, Default)]
 struct RegisterSignal;
 
 impl NativeClass for RegisterSignal {
     type Base = Reference;
-    type UserData = user_data::ArcData<RegisterSignal>;
+    type UserData = user_data::Aether<RegisterSignal>;
     fn class_name() -> &'static str {
         "RegisterSignal"
     }


### PR DESCRIPTION
`Aether` is a special user-data wrapper intended for zero-sized types, that does not perform any allocation or synchronization. It produces a value using `Default` each time it's mapped. This is most useful when used with auto-load scripts to simulate static functions, since actual static functions can't be exported in GDNative.

Close #380. Close #381.